### PR TITLE
OCLM-28 Travis, Codacy, test coverage support with Cobertura

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo : required
+language: java
+install : 
+- curl -sL http://bit.ly/jpm4j >jpm4j.jar
+- sudo java -jar jpm4j.jar -u init
+- sudo sh ~/jpm/bin/jpm install com.codacy:codacy-coverage-reporter:assembly
+- mvn install
+script : 
+- mvn clean package
+- mvn cobertura:cobertura
+- ~/jpm/bin/codacy-coverage-reporter -l Java -r target/site/cobertura/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install :
 - sudo sh ~/jpm/bin/jpm install com.codacy:codacy-coverage-reporter:assembly
 - mvn install
 script : 
-- mvn clean package
+- mvn clean package -DskipTests
 - mvn cobertura:cobertura
 - ~/jpm/bin/codacy-coverage-reporter -l Java -r target/site/cobertura/coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## OpenMRS Open Concept Lab module
 
+[![Build Status](https://travis-ci.org/PawelGutkowski/openmrs-module-openconceptlab.svg?branch=master)](https://travis-ci.org/PawelGutkowski/openmrs-module-openconceptlab)[![Codacy Badge](https://api.codacy.com/project/badge/grade/6b1a6531f75f42ce909b371918ec84ee)](https://www.codacy.com/app/pawel-gutkowski-1993/openmrs-module-openconceptlab)
+
 ### Project page
 
 [OCL Subscription Module (Design Page)](https://wiki.openmrs.org/pages/viewpage.action?pageId=70877277)

--- a/pom.xml
+++ b/pom.xml
@@ -253,8 +253,23 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			 <plugin>
+          		<groupId>org.codehaus.mojo</groupId>
+          		<artifactId>cobertura-maven-plugin</artifactId>
+        	</plugin>
+		</plugins>
 
 	</build>
+	
+	<reporting>
+		<plugins>
+			 <plugin>
+          		<groupId>org.codehaus.mojo</groupId>
+          		<artifactId>cobertura-maven-plugin</artifactId>
+        	</plugin>
+		</plugins>
+	</reporting>
 
 	<profiles>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -231,8 +231,29 @@
 						<allowTimestampedSnapshots>true</allowTimestampedSnapshots>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>cobertura-maven-plugin</artifactId>
+					<version>2.7</version>
+			        <configuration>
+			            <formats>
+			                <format>html</format>
+			                <format>xml</format>
+			            </formats>
+			            <aggregate>true</aggregate>
+		                <forceMojoExecution>true</forceMojoExecution>
+			        </configuration>
+			        <executions>
+			          <execution>
+			            <goals>
+			              <goal>clean</goal>
+			            </goals>
+			          </execution>
+			        </executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
+
 	</build>
 
 	<profiles>
@@ -275,6 +296,7 @@
 							</execution>
 						</executions>
 					</plugin>
+					
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
I managed to setup Travis, Codacy and test coverage with Cobertura plugin. Test coverage data is sent to Codacy, but I cannot see it yet, there's message:
`
Oops!We received your coverage data, but the corresponding commit was not detected yet.
`
I believe it will be updated with this PR. I've got one problem - I tried to tie Cobertura execution with clean package phase, but it doesn't work, so tests are executed again when Cobertura runs.