### PR TITLE
OCLM-38 - Subscribe to snapshot or released versions

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/Import.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/Import.java
@@ -45,6 +45,10 @@ public class Import {
 	@Basic
 	@Column(name = "ocl_date_started")
 	private Date oclDateStarted;
+
+	@Basic
+	@Column(name = "release_version")
+	private String releaseVersion;
 	
 	@Basic
 	@Column(name = "error_message")
@@ -80,6 +84,14 @@ public class Import {
 	
 	public void setOclDateStarted(Date oclDateStarted) {
 		this.oclDateStarted = oclDateStarted;
+	}
+
+	public String getReleaseVersion() {
+		return releaseVersion;
+	}
+
+	public void setReleaseVersion(String releaseVersion) {
+		this.releaseVersion = releaseVersion;
 	}
 	
     public String getErrorMessage() {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/ImportService.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ImportService.java
@@ -59,6 +59,8 @@ public interface ImportService {
     @Transactional
 	void updateOclDateStarted(Import update, Date oclDateStarted);
 
+	void updateReleaseVersion(Import anImport, String version);
+
 	/**
 	 * @should throw IllegalArgumentException if not scheduled
 	 * @should throw IllegalStateException if trying to stop twice

--- a/api/src/main/java/org/openmrs/module/openconceptlab/ImportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ImportServiceImpl.java
@@ -184,7 +184,15 @@ public class ImportServiceImpl implements ImportService {
 
 	@Override
 	public Boolean isLastImportSuccessful(){
-		return getLastSuccessfulSubscriptionImport().equals(getLastImport());
+
+		Import lastSuccessfulSubscriptionImport = getLastSuccessfulSubscriptionImport();
+		if (lastSuccessfulSubscriptionImport != null) {
+			Import lastUpdate = getLastImport();
+			return lastSuccessfulSubscriptionImport.equals(lastUpdate);
+		}
+		else {
+			return false;
+		}
 	}
 	
 	@Override
@@ -232,6 +240,12 @@ public class ImportServiceImpl implements ImportService {
 	public void updateOclDateStarted(Import update, Date oclDateStarted) {
 		update.setOclDateStarted(oclDateStarted);
 		getSession().save(update);
+	}
+
+	@Override
+	public void updateReleaseVersion(Import anImport, String version) {
+		anImport.setReleaseVersion(version);
+		getSession().save(anImport);
 	}
 
 

--- a/api/src/main/java/org/openmrs/module/openconceptlab/Subscription.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/Subscription.java
@@ -28,6 +28,8 @@ public class Subscription {
 
 	private Integer minutes = 0;
 
+	private boolean subscribedToSnapshot = true;
+
 	public Subscription() {
 
 	}
@@ -82,6 +84,14 @@ public class Subscription {
 	
 	public boolean isManual() {
 		return (days == null && hours == null && minutes == null) || (days == 0 && hours == 0 && minutes == 0);
+	}
+
+	public boolean isSubscribedToSnapshot() {
+		return subscribedToSnapshot;
+	}
+
+	public void setSubscribedToSnapshot(boolean isFetchingSnapshotUpdates) {
+		this.subscribedToSnapshot = isFetchingSnapshotUpdates;
 	}
 	
 	public boolean isSubscribed() {

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -206,4 +206,16 @@
 		<addForeignKeyConstraint constraintName="openconceptlab_item_import" baseTableName="openconceptlab_item" baseColumnNames="import_id" referencedTableName="openconceptlab_import" referencedColumnNames="import_id"/>
 	</changeSet>
 
+    <changeSet author="tomaszmarzeion" id="openconceptlab-v1-12">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="openconceptlab_import" columnName="release_version"/>
+            </not>
+        </preConditions>
+        <comment>Create release_version - See OCLM-38 for details</comment>
+        <addColumn tableName="openconceptlab_import">
+            <column name="release_version" type="varchar(512)"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/module/openconceptlab/UpdateServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/UpdateServiceTest.java
@@ -9,34 +9,44 @@
  */
 package org.openmrs.module.openconceptlab;
 
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matcher;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.openmrs.Concept;
+import org.openmrs.ConceptName;
+import org.openmrs.api.ConceptNameType;
+import org.openmrs.api.ConceptService;
+import org.openmrs.module.openconceptlab.client.OclClient;
+import org.openmrs.module.openconceptlab.importer.Importer;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.File;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
-
-import org.hamcrest.Matcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.openmrs.Concept;
-import org.openmrs.ConceptName;
-import org.openmrs.api.ConceptNameType;
-import org.openmrs.api.ConceptService;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
-import org.springframework.beans.factory.annotation.Autowired;
+import static org.mockito.Mockito.when;
 
 public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 
 	@Autowired
-	ImportService updateService;
+	private ImportService importService;
 
-	@Autowired
-	ConceptService conceptService;
+    @Mock
+    private ImportService mockedUpdateService;
+
+    @Autowired
+    private ConceptService conceptService;
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
@@ -48,9 +58,9 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void getUpdate_shouldReturnUpdateWithId() throws Exception {
 		Import newUpdate = new Import();
-		updateService.startImport(newUpdate);
+		importService.startImport(newUpdate);
 
-		Import update = updateService.getImport(newUpdate.getImportId());
+		Import update = importService.getImport(newUpdate.getImportId());
 
 		assertThat(update, is(newUpdate));
 	}
@@ -62,7 +72,7 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void getUpdate_shouldThrowIllegalArgumentExceptionIfUpdateDoesNotExist() throws Exception {
 		exception.expect(IllegalArgumentException.class);
-		updateService.getImport(0L);
+		importService.getImport(0L);
 
 	}
 
@@ -73,13 +83,13 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void getUpdatesInOrder_shouldReturnAllUpdatesOrderedDescendingByIds() throws Exception {
 		Import firstUpdate = new Import();
-		updateService.startImport(firstUpdate);
-		updateService.stopImport(firstUpdate);
+		importService.startImport(firstUpdate);
+		importService.stopImport(firstUpdate);
 
 		Import secondUpdate = new Import();
-		updateService.startImport(secondUpdate);
+		importService.startImport(secondUpdate);
 
-		List<Import> updatesInOrder = updateService.getImportsInOrder(0, 20);
+		List<Import> updatesInOrder = importService.getImportsInOrder(0, 20);
 
 		assertThat(updatesInOrder, contains(secondUpdate, firstUpdate));
 	}
@@ -91,11 +101,11 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
     @Test
     public void scheduleUpdate_shouldThrowIllegalStateExceptionIfAnotherUpdateIsInProgress() throws Exception {
     	Import firstUpdate = new Import();
-    	updateService.startImport(firstUpdate);
+    	importService.startImport(firstUpdate);
 
     	Import secondUpdate = new Import();
     	exception.expect(IllegalStateException.class);
-    	updateService.startImport(secondUpdate);
+    	importService.startImport(secondUpdate);
     }
 
 	/**
@@ -106,7 +116,7 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
     public void stopUpdate_shouldThrowIllegalArgumentExceptionIfNotScheduled() throws Exception {
     	Import update = new Import();
     	exception.expect(IllegalArgumentException.class);
-    	updateService.stopImport(update);
+    	importService.stopImport(update);
     }
 
 	/**
@@ -116,11 +126,11 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
     @Test
     public void stopUpdate_shouldThrowIllegalStateExceptionIfTryingToStopTwice() throws Exception {
     	Import update = new Import();
-    	updateService.startImport(update);
-    	updateService.stopImport(update);
+    	importService.startImport(update);
+    	importService.stopImport(update);
 
     	exception.expect(IllegalStateException.class);
-    	updateService.stopImport(update);
+    	importService.stopImport(update);
     }
 
 	/**
@@ -136,11 +146,107 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 		newSubscription.setMinutes(30);
 		newSubscription.setToken("c84e5a66d8b2e9a9bf1459cd81e6357f1c6a997e");
 
-		updateService.saveSubscription(newSubscription);
+		importService.saveSubscription(newSubscription);
 
-		Subscription subscription = updateService.getSubscription();
+		Subscription subscription = importService.getSubscription();
 		assertThat(subscription, is(newSubscription));
 	}
+
+    /*
+     * TODO:
+     * These ignored tests are working fine,
+     * but it takes too much time to finish them
+     * since tests are downloading data from real OCL.
+     * This issue will be fixed when there will be prepared
+     * test data, which will be easier to fetch.
+     */
+    @Ignore("This test is used for update simulation")
+	@Test
+	public void startUpdate_shouldStartInitialUpdate() throws Exception {
+		Subscription newSubscription = new Subscription();
+		newSubscription.setUrl("http://api.openconceptlab.com/orgs/CIEL/sources/CIEL/");
+		newSubscription.setToken("41062d8fd2bcf5eb5457988bbe2dcb5446a80a07");
+
+		importService.saveSubscription(newSubscription);
+        Importer importer = new Importer();
+
+        File tempDir = File.createTempFile("ocl", "");
+        FileUtils.deleteQuietly(tempDir);
+        tempDir.deleteOnExit();
+        OclClient oclClient = new OclClient(tempDir.getAbsolutePath());
+
+        importer.setOclClient(oclClient);
+        importer.setImportService(importService);
+
+        importer.runTask();
+	}
+
+    @Ignore("This test is used for update simulation")
+    @Test
+    public void startUpdate_shouldStartReleaseUpdate() throws Exception {
+        Subscription subscription = new Subscription();
+        subscription.setUrl("http://api.openconceptlab.com/orgs/CIEL/sources/CIEL/");
+        subscription.setToken("41062d8fd2bcf5eb5457988bbe2dcb5446a80a07");
+        subscription.setSubscribedToSnapshot(false);
+
+        Import anImport = new Import();
+        anImport.setErrorMessage(null);
+        anImport.setOclDateStarted(new Date());
+        anImport.setReleaseVersion("some_outdated_version_v4.2.0");
+
+        when(mockedUpdateService.getSubscription()).thenReturn(subscription);
+        when(mockedUpdateService.getLastSuccessfulSubscriptionImport()).thenReturn(anImport);
+
+        File tempDir = File.createTempFile("ocl", "");
+        FileUtils.deleteQuietly(tempDir);
+        tempDir.deleteOnExit();
+        OclClient oclClient = new OclClient(tempDir.getAbsolutePath());
+
+        Importer importer = new Importer();
+
+        importer.setOclClient(oclClient);
+        importer.setImportService(mockedUpdateService);
+
+        importer.runTask();
+    }
+
+	@Ignore("This test is used for update simulation")
+	@Test
+    public void startUpdate_shouldStartSnapshotUpdate() throws Exception {
+        Subscription subscription = new Subscription();
+        subscription.setUrl("http://api.openconceptlab.com/orgs/CIEL/sources/CIEL/");
+        subscription.setToken("41062d8fd2bcf5eb5457988bbe2dcb5446a80a07");
+        subscription.setSubscribedToSnapshot(true);
+
+        Import anImport = new Import();
+        anImport.setErrorMessage(null);
+        anImport.setOclDateStarted(new Date());
+        anImport.setReleaseVersion("some_outdated_version_v4.2.0");
+
+        when(mockedUpdateService.getSubscription()).thenReturn(subscription);
+        when(mockedUpdateService.getLastSuccessfulSubscriptionImport()).thenReturn(anImport);
+
+        File tempDir = File.createTempFile("ocl", "");
+        FileUtils.deleteQuietly(tempDir);
+        tempDir.deleteOnExit();
+        OclClient oclClient = new OclClient(tempDir.getAbsolutePath());
+
+        Importer updater = new Importer();
+
+        updater.setOclClient(oclClient);
+        updater.setImportService(mockedUpdateService);
+
+        updater.runTask();
+    }
+
+    @Test
+    public void update_shouldUpdateLatestDownloadedRelease() throws Exception {
+        Import anImport = new Import();
+        anImport.setOclDateStarted(new Date());
+        final String version = "v1.2";
+        importService.updateReleaseVersion(anImport, version);
+        assertThat(version, is(importService.getLastSuccessfulSubscriptionImport().getReleaseVersion()));
+    }
 
 	@Test
 	public void getDuplicateConceptNames_shoudlFindDuplicates() throws Exception {
@@ -161,7 +267,9 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 		nameToImport.setLocale(new Locale("vi"));
 		conceptToImport.addName(nameToImport);
 
-		List<ConceptName> duplicateOclNames = updateService.changeDuplicateConceptNamesToIndexTerms(conceptToImport);
+		List<ConceptName> duplicateOclNames = importService.changeDuplicateConceptNamesToIndexTerms(conceptToImport);
 		assertThat(duplicateOclNames, contains((Matcher<? super ConceptName>) hasProperty("name", is("Rubella Viêm não"))));
 	}
+
+
 }

--- a/omod/src/main/java/org/openmrs/module/openconceptlab/fragment/controller/StatusFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/openconceptlab/fragment/controller/StatusFragmentController.java
@@ -34,8 +34,10 @@ public class StatusFragmentController {
 							@SpringBean("openconceptlab.updateService") ImportService updateService,
 							@RequestParam(required = false, value = "ignoreErrors") Boolean ignoreErrors) throws IOException {
 		
-		Import update = updateService.getLastImport();
-		updateService.ignoreAllErrors(update);
+		Import anImport = updateService.getLastImport();
+		if (anImport != null) {
+			updateService.ignoreAllErrors(anImport);
+		}
 		updateScheduler.scheduleNow();
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/openconceptlab/web/rest/resources/SubscriptionResource.java
+++ b/omod/src/main/java/org/openmrs/module/openconceptlab/web/rest/resources/SubscriptionResource.java
@@ -22,7 +22,6 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 import java.util.Collections;
-import java.util.Date;
 import java.util.UUID;
 
 @Resource(name = RestConstants.VERSION_1 + OpenConceptLabRestController.OPEN_CONCEPT_LAB_REST_NAMESPACE + "/subscription", supportedClass = Subscription.class, supportedOpenmrsVersions = { "1.8.*",
@@ -56,6 +55,7 @@ public class SubscriptionResource extends DelegatingCrudResource<Subscription> {
         DelegatingResourceDescription delegatingResourceDescription = new DelegatingResourceDescription();
         delegatingResourceDescription.addRequiredProperty("url");
         delegatingResourceDescription.addRequiredProperty("token");
+        delegatingResourceDescription.addProperty("subscribedToSnapshot");
         return delegatingResourceDescription;
     }
 
@@ -71,6 +71,7 @@ public class SubscriptionResource extends DelegatingCrudResource<Subscription> {
             description.addProperty("uuid");
             description.addProperty("url");
             description.addProperty("token");
+            description.addProperty("subscribedToSnapshot");
             description.addLink("ref", ".?v=" + RestConstants.REPRESENTATION_REF);
             description.addSelfLink();
             return description;

--- a/owa/app/js/subscription/subscription.html
+++ b/owa/app/js/subscription/subscription.html
@@ -11,6 +11,7 @@
                     <label name="subscription-token">{{"tokenurl.label" | translate}}</label><br>
                     <input id="subscription-token" ng-model="vm.subscription.token" style="width: 60%" required/>
                 </p>
+                <input ng-model="vm.subscription.subscribedToSnapshot" type="checkbox"> {{"subscription.options.checkbox" | translate}}<br>
             </div>
             <br>
             <div>

--- a/owa/app/translation/messages_en.json
+++ b/owa/app/translation/messages_en.json
@@ -6,6 +6,7 @@
   "instalupdatesmanually.radio":"Install updates manually",
   "instalupdatesautomatically.radio":"Install updates automatically",
   "subscribe.button":"Save changes",
+  "subscription.options.checkbox":"Subscribe to SNAPSHOT versions (not recommended)",
   "cancelchanges.button":"Cancel Changes",
   "nosubscriptionmessage.info":"You are not subscribed to Open Concept Lab. Please go to the configuration page to setup the subscription",
   "installupdatesperiod.text":"Install updates every",


### PR DESCRIPTION
What is done here:
- column `release_version` added to `openconceptlab_update` table, it is used to check if latest OCL release is newer than one downloaded by OpenMRS OCL Client.
- `fetchUpdates()` method in `OclClient` is now renamed to `fetchSnapshotUpdates()`.
- `fetchSnapshotUpdates()` is called only when `isSubscribedToSnapshot()` in `Subscription` returns `true`.
- `fetchInitialUpdates()` is renamed to `fetchReleaseUpdates()`
- `fetchReleaseUpdates()` overloaded method is added, this method checks if last downloaded version is up to date with OCL release version. If yes, old `fetchReleaseUpdates()` is called.

I've added 3 test methods used to start update.
`startUpdate_shouldStartInitialUpdate()` - Starts initial update
`startUpdate_shouldStartReleaseUpdate()` - Starts followup update (only release version updates)
`startUpdate_shouldStartSnapshotUpdate()` - Starts followup update (with SNAPSHOT versions included)
These methods are `@Ignored` because tests are fetching data from original source, so it takes a lot of time (about 13 mins per test) to finish these tests. This issue will be fixed when some custom, small sized test-exclusive data will be created.

There is also `update_shouldUpdateLatestDownloadedRelease()` test method, which checks if new `String lastDownloadedRelease` field in `Update` object is successfully saved into DB.

**Summary:**
This code works like it worked before, until `boolean isFetchingSnapshotUpdates` in `Subscription` isn't changed to `false`, which is going to be implemented in new UI.
when `isFetchingSnapshotUpdates` is set to false, there is new logic triggered in `Updater`, which calls `OclClient` overloaded `fetchReleaseUpdates()` method that does update if new source version is released.