### PR TITLE
OCLM-46 - Mock OCL Response - WIP

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/ImportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ImportServiceImpl.java
@@ -321,6 +321,9 @@ public class ImportServiceImpl implements ImportService {
 			subscription.setDays(Integer.valueOf(days));
 		}
 
+		String subscribedToSnapshot = adminService.getGlobalProperty(OpenConceptLabConstants.GP_SUBSCRIBED_TO_SNAPSHOT);
+		subscription.setSubscribedToSnapshot(Boolean.valueOf(subscribedToSnapshot));
+
 		String time = adminService.getGlobalProperty(OpenConceptLabConstants.GP_SCHEDULED_TIME);
 		if (!StringUtils.isBlank(time)) {
 			String[] formattedTime = time.split(":");
@@ -384,6 +387,14 @@ public class ImportServiceImpl implements ImportService {
 			time.setPropertyValue("");
 		}
 		adminService.saveGlobalProperty(time);
+
+		GlobalProperty subscribedToSnapshot = adminService.getGlobalPropertyObject(OpenConceptLabConstants.GP_SUBSCRIBED_TO_SNAPSHOT);
+		if (subscribedToSnapshot == null) {
+			subscribedToSnapshot = new GlobalProperty(OpenConceptLabConstants.GP_SUBSCRIBED_TO_SNAPSHOT);
+		}
+		subscribedToSnapshot.setPropertyValue(String.valueOf(subscription.isSubscribedToSnapshot()));
+		adminService.saveGlobalProperty(subscribedToSnapshot);
+
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabConstants.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabConstants.java
@@ -31,4 +31,5 @@ public class OpenConceptLabConstants {
 	public static final String GP_SCHEDULED_DAYS = MODULE_ID + ".scheduledDays";
 	public static final String GP_SCHEDULED_TIME = MODULE_ID + ".scheduledTime";
 	public static final String GP_TOKEN = MODULE_ID + ".token";
+	public static final String GP_SUBSCRIBED_TO_SNAPSHOT = MODULE_ID + ".subscribedToSnapshot";
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java
@@ -110,19 +110,23 @@ public class OclClient {
 		String latestVersion = fetchLatestOclReleaseVersion(url, token);
 		
 		String exportUrl = fetchExportUrl(url, token, latestVersion);
-		
-		GetMethod exportUrlGet = new GetMethod(exportUrl);
-		
-		HttpClient client = new HttpClient();
-		client.getHttpConnectionManager().getParams().setSoTimeout(TIMEOUT_IN_MS);
-		client.executeMethod(exportUrlGet);
-		
+
+		GetMethod exportUrlGet = executeResponse(exportUrl);
+
 		if (exportUrlGet.getStatusCode() != 200) {
 			throw new IOException(exportUrlGet.getStatusLine().toString());
 		}
 		
 		return extractResponse(exportUrlGet);
     }
+
+	public GetMethod executeResponse(String exportUrl) throws IOException {
+		GetMethod get = new GetMethod(exportUrl);
+		HttpClient client = new HttpClient();
+		client.getHttpConnectionManager().getParams().setSoTimeout(TIMEOUT_IN_MS);
+		client.executeMethod(get);
+		return get;
+	}
 
 	public OclResponse fetchLastReleaseVersion(String url, String token, String lastReleaseVersion) throws IOException {
 		String latestOclReleaseVersion = fetchLatestOclReleaseVersion(url, token);
@@ -149,6 +153,7 @@ public class OclClient {
 		}
 		
 		File file = newFile(date);
+
 		download(get.getResponseBodyAsStream(), get.getResponseContentLength(), file);
 		
 		InputStream response = new FileInputStream(file);
@@ -162,7 +167,7 @@ public class OclClient {
 		}
 	}
 
-	Date parseDateFromPath(String path) throws IOException {
+	public Date parseDateFromPath(String path) throws IOException {
 	    Pattern pattern = Pattern.compile("[0-9]*.tgz");
 	    Matcher matcher = pattern.matcher(path);
 	    if (matcher.find()) {
@@ -303,7 +308,7 @@ public class OclClient {
 		}
 	}
 
-	private String fetchExportUrl(String url, String token, String latestVersion) throws IOException, HttpException {
+	public String fetchExportUrl(String url, String token, String latestVersion) throws IOException, HttpException {
 	    String latestVersionExportUrl = url + "/" + latestVersion + "/export";
 		
 		GetMethod latestVersionExportUrlGet = new GetMethod(latestVersionExportUrl);

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/ImportTask.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/ImportTask.java
@@ -59,58 +59,61 @@ public class ImportTask implements Runnable {
 	@Override
 	public void run() {
 		Daemon.runInDaemonThreadAndWait(new Runnable() {
-			
 			@Override
 			public void run() {
-				anImport = updateService.getImport(anImport.getImportId());
-				
-				if (oclConcepts != null) {
-					List<Item> items = new ArrayList<Item>();
-					
-					for (OclConcept oclConcept : oclConcepts) {
-						Item item = null;
-						try {
-							item = importer.saveConcept(cacheService, anImport, oclConcept);
-							log.info("Imported concept " + oclConcept);
-						}
-						catch (Throwable e) {
-							log.error("Failed to import concept " + oclConcept, e);
-							Context.clearSession();
-							cacheService.clearCache();
-
-							item = new Item(anImport, oclConcept, ItemState.ERROR);
-							item.setErrorMessage(Importer.getErrorMessage(e));
-						} finally {
-							items.add(item);
-						}
-	                }
-					updateService.saveItems(items);
-				}
-				
-				if (oclMappings != null) {
-					List<Item> items = new ArrayList<Item>();
-					
-					for (OclMapping oclMapping : oclMappings) {
-						Item item = null;
-						try {
-							item = importer.saveMapping(cacheService, anImport, oclMapping);
-							log.info("Imported mapping " + oclMapping);
-						}
-						catch (Throwable e) {
-							log.error("Failed to import mapping " + oclMapping, e);
-							Context.clearSession();
-							cacheService.clearCache();
-														
-							item = new Item(anImport, oclMapping, ItemState.ERROR);
-							item.setErrorMessage(Importer.getErrorMessage(e));
-						} finally {
-							items.add(item);
-						}
-                    }
-					
-					updateService.saveItems(items);
-				}
+				//TODO: Call it directly instead of in Daemon.runInDaemonThreadAndWait()
+				runTask();
 			}
 		}, OpenConceptLabActivator.getDaemonToken());
+	}
+
+	public void runTask() {
+		anImport = updateService.getImport(anImport.getImportId());
+		if (oclConcepts != null) {
+			List<Item> items = new ArrayList<Item>();
+
+			for (OclConcept oclConcept : oclConcepts) {
+				Item item = null;
+				try {
+					item = importer.saveConcept(cacheService, anImport, oclConcept);
+					log.info("Imported concept " + oclConcept);
+				}
+				catch (Throwable e) {
+					log.error("Failed to import concept " + oclConcept, e);
+					Context.clearSession();
+					cacheService.clearCache();
+
+					item = new Item(anImport, oclConcept, ItemState.ERROR);
+					item.setErrorMessage(Importer.getErrorMessage(e));
+				} finally {
+					items.add(item);
+				}
+			}
+			updateService.saveItems(items);
+		}
+
+		if (oclMappings != null) {
+			List<Item> items = new ArrayList<Item>();
+
+			for (OclMapping oclMapping : oclMappings) {
+				Item item = null;
+				try {
+					item = importer.saveMapping(cacheService, anImport, oclMapping);
+					log.info("Imported mapping " + oclMapping);
+				}
+				catch (Throwable e) {
+					log.error("Failed to import mapping " + oclMapping, e);
+					Context.clearSession();
+					cacheService.clearCache();
+
+					item = new Item(anImport, oclMapping, ItemState.ERROR);
+					item.setErrorMessage(Importer.getErrorMessage(e));
+				} finally {
+					items.add(item);
+				}
+			}
+
+			updateService.saveItems(items);
+		}
 	}
 }

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -54,7 +54,7 @@
 		<property name="importService" ref="openconceptlab.importService" />
 		<property name="conceptService" ref="conceptService" />
 		<property name="oclClient" ref="openconceptlab.oclClient" />
-		<property name="persister" ref="openconceptlab.saver" />
+		<property name="saver" ref="openconceptlab.saver" />
 	</bean>
 	
 	<bean id="openconceptlab.updateScheduler" class="org.openmrs.module.openconceptlab.scheduler.UpdateScheduler">

--- a/api/src/test/java/org/openmrs/module/openconceptlab/UpdateServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/UpdateServiceTest.java
@@ -9,13 +9,17 @@
  */
 package org.openmrs.module.openconceptlab;
 
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matcher;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.openmrs.Concept;
 import org.openmrs.ConceptName;
 import org.openmrs.api.ConceptNameType;
@@ -23,9 +27,13 @@ import org.openmrs.api.ConceptService;
 import org.openmrs.module.openconceptlab.client.OclClient;
 import org.openmrs.module.openconceptlab.importer.Importer;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -34,7 +42,9 @@ import java.util.UUID;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
@@ -42,14 +52,28 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 	@Autowired
 	private ImportService importService;
 
+    @Autowired
+    private Importer importer;
+
     @Mock
-    private ImportService mockedUpdateService;
+    private ImportService mockedImportService;
 
     @Autowired
     private ConceptService conceptService;
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
+
+	@Spy
+	private OclClient mockedOclClient;
+
+	@Mock
+	private GetMethod mockedGetMethod;
+
+    @Before
+    public void before() {
+        TestResources.setupDaemonToken();
+    }
 
 	/**
 	 * @see ImportServiceImpl#getImport(Long)
@@ -77,7 +101,7 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 	}
 
 	/**
-	 * @see ImportServiceImpl#getUpdatesInOrder()
+	 * @see ImportServiceImpl#getImportsInOrder()
 	 * @verifies return all updates ordered descending by ids
 	 */
 	@Test
@@ -153,14 +177,10 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 	}
 
     /*
-     * TODO:
-     * These ignored tests are working fine,
-     * but it takes too much time to finish them
-     * since tests are downloading data from real OCL.
-     * This issue will be fixed when there will be prepared
-     * test data, which will be easier to fetch.
+     * This is used to trigger real OCLM<->OCLAPI logic
+     * @Ignored, because it takes too much time to fetch real data
      */
-    @Ignore("This test is used for update simulation")
+    @Ignore("This test is used to triggering real OCLM-OCLAPI logic")
 	@Test
 	public void startUpdate_shouldStartInitialUpdate() throws Exception {
 		Subscription newSubscription = new Subscription();
@@ -168,7 +188,6 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 		newSubscription.setToken("41062d8fd2bcf5eb5457988bbe2dcb5446a80a07");
 
 		importService.saveSubscription(newSubscription);
-        Importer importer = new Importer();
 
         File tempDir = File.createTempFile("ocl", "");
         FileUtils.deleteQuietly(tempDir);
@@ -181,7 +200,7 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
         importer.runTask();
 	}
 
-    @Ignore("This test is used for update simulation")
+    @Ignore("This test is used to triggering real OCLM-OCLAPI logic")
     @Test
     public void startUpdate_shouldStartReleaseUpdate() throws Exception {
         Subscription subscription = new Subscription();
@@ -194,23 +213,21 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
         anImport.setOclDateStarted(new Date());
         anImport.setReleaseVersion("some_outdated_version_v4.2.0");
 
-        when(mockedUpdateService.getSubscription()).thenReturn(subscription);
-        when(mockedUpdateService.getLastSuccessfulSubscriptionImport()).thenReturn(anImport);
+        when(mockedImportService.getSubscription()).thenReturn(subscription);
+        when(mockedImportService.getLastSuccessfulSubscriptionImport()).thenReturn(anImport);
 
         File tempDir = File.createTempFile("ocl", "");
         FileUtils.deleteQuietly(tempDir);
         tempDir.deleteOnExit();
         OclClient oclClient = new OclClient(tempDir.getAbsolutePath());
 
-        Importer importer = new Importer();
-
         importer.setOclClient(oclClient);
-        importer.setImportService(mockedUpdateService);
+        importer.setImportService(mockedImportService);
 
         importer.runTask();
     }
 
-	@Ignore("This test is used for update simulation")
+    @Ignore("This test is used to triggering real OCLM-OCLAPI logic")
 	@Test
     public void startUpdate_shouldStartSnapshotUpdate() throws Exception {
         Subscription subscription = new Subscription();
@@ -223,21 +240,229 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
         anImport.setOclDateStarted(new Date());
         anImport.setReleaseVersion("some_outdated_version_v4.2.0");
 
-        when(mockedUpdateService.getSubscription()).thenReturn(subscription);
-        when(mockedUpdateService.getLastSuccessfulSubscriptionImport()).thenReturn(anImport);
+        when(mockedImportService.getSubscription()).thenReturn(subscription);
+        when(mockedImportService.getLastSuccessfulSubscriptionImport()).thenReturn(anImport);
 
         File tempDir = File.createTempFile("ocl", "");
         FileUtils.deleteQuietly(tempDir);
         tempDir.deleteOnExit();
         OclClient oclClient = new OclClient(tempDir.getAbsolutePath());
 
-        Importer updater = new Importer();
+        importer.setOclClient(oclClient);
+        importer.setImportService(mockedImportService);
 
-        updater.setOclClient(oclClient);
-        updater.setImportService(mockedUpdateService);
-
-        updater.runTask();
+        importer.runTask();
     }
+
+	@Ignore("WIP - OCLM-46")
+	@Test
+	public void mockUpdate_shouldImportInitialDataFromMockedResponse() throws Exception {
+
+		Subscription subscription = new Subscription();
+		subscription.setUrl("http://api.openconceptlab.com/orgs/CIEL/sources/CIEL");
+		subscription.setToken("41062d8fd2bcf5eb5457988bbe2dcb5446a80a07");
+
+		final String filename = "CIEL_20150514-testdata.20150622121229.tar";
+
+		final String releaseVersion = "1.2";
+		final String exportUrl = "https://ocl-source-export-production.s3.amazonaws.com/CIEL/"
+				+ filename
+				+ "?Signature=p6C4oOtz%2Fgcom5PqXDDnFexeLfg%3D&Expires=1478508163&AWSAccessKeyId=AKIAJSVYSQTANHNWOOPQ";
+
+        importService.saveSubscription(subscription);
+
+        // Mock latest release version http request
+		doReturn(releaseVersion).when(mockedOclClient).fetchLatestOclReleaseVersion(
+                subscription.getUrl(),
+                subscription.getToken());
+
+		// Mock export url
+		doReturn(exportUrl).when(mockedOclClient).fetchExportUrl(
+                subscription.getUrl(),
+                subscription.getToken(),
+				releaseVersion);
+
+		doReturn(mockedGetMethod).when(mockedOclClient).executeResponse(exportUrl);
+
+		final String dateHeaderValue = "Mon, 07 Nov 2016 09:52:34 GMT";
+		Header dateHeader = new Header();
+		dateHeader.setName("Date");
+		dateHeader.setValue(dateHeaderValue);
+
+		// Mock response date header
+		when(mockedGetMethod.getStatusCode()).thenReturn(200);
+		when(mockedGetMethod.getResponseHeader("Date")).thenReturn(dateHeader);
+
+		File oclResponseTarfile = new File("src/test/resources/", filename);
+        ByteArrayInputStream fileInputStream = new ByteArrayInputStream(FileUtils.readFileToByteArray(oclResponseTarfile));
+
+		// Mock response
+		when(mockedGetMethod.getResponseBodyAsStream()).thenReturn(fileInputStream);
+		when(mockedGetMethod.getResponseContentLength()).thenReturn(Long.valueOf(fileInputStream.available()));
+		when(mockedGetMethod.getPath()).thenReturn(null);
+
+		doReturn(new Date()).when(mockedOclClient).parseDateFromPath(null);
+
+		importer.setOclClient(mockedOclClient);
+		importer.setImportService(importService);
+
+		importer.run();
+
+        Concept concept = conceptService.getConceptByUuid("54ea96d28a86f20421474a3a");
+
+        assertThat(concept, is(notNullValue()));
+	}
+
+    @Ignore("WIP - OCLM-46")
+	@Test
+	public void mockUpdate_shouldImportLatestReleaseMockedResponse() throws Exception {
+
+		Subscription subscription = new Subscription();
+		subscription.setUrl("http://api.openconceptlab.com/orgs/CIEL/sources/CIEL");
+		subscription.setToken("41062d8fd2bcf5eb5457988bbe2dcb5446a80a07");
+		subscription.setSubscribedToSnapshot(false);
+
+		final String filename = "CIEL_20150514-testdata.20150622121229.tar";
+
+		final String outdatedReleaseVersion = "1.2";
+		final String actualReleaseVersion = "1.3";
+
+		final String exportUrl = "https://ocl-source-export-production.s3.amazonaws.com/CIEL/"
+				+ filename
+				+ "?Signature=p6C4oOtz%2Fgcom5PqXDDnFexeLfg%3D&Expires=1478508163&AWSAccessKeyId=AKIAJSVYSQTANHNWOOPQ";
+
+		//TODO: getSubscription() in ImportServiceImpl.java
+		importService.saveSubscription(subscription);
+
+		// Mock latest release version http request
+		doReturn(outdatedReleaseVersion).when(mockedOclClient).fetchLatestOclReleaseVersion(
+				importService.getSubscription().getUrl(),
+				importService.getSubscription().getToken());
+
+		// Mock export url
+		doReturn(exportUrl).when(mockedOclClient).fetchExportUrl(
+				importService.getSubscription().getUrl(),
+				importService.getSubscription().getToken(),
+				outdatedReleaseVersion);
+
+		doReturn(mockedGetMethod).when(mockedOclClient).executeResponse(exportUrl);
+
+		final String dateHeaderValue = "Mon, 07 Nov 2016 09:52:34 GMT";
+		Header dateHeader = new Header();
+		dateHeader.setName("Date");
+		dateHeader.setValue(dateHeaderValue);
+
+		// Mock response date header
+		when(mockedGetMethod.getStatusCode()).thenReturn(200);
+		when(mockedGetMethod.getResponseHeader("Date")).thenReturn(dateHeader);
+
+		final String oclInitialResponseTarfilename = "CIEL_20150514-testdata.20150622121229.tar";
+		File oclInitialResponseTarfile = new File("src/test/resources/", oclInitialResponseTarfilename);
+		FileInputStream initialResponseFileInputStream = new FileInputStream(oclInitialResponseTarfile);
+
+		// Mock response
+		when(mockedGetMethod.getResponseBodyAsStream()).thenReturn(initialResponseFileInputStream);
+		when(mockedGetMethod.getResponseContentLength()).thenReturn(Long.valueOf(initialResponseFileInputStream.available()));
+		when(mockedGetMethod.getPath()).thenReturn(null);
+
+		doReturn(new Date()).when(mockedOclClient).parseDateFromPath(null);
+
+		//TODO Mock thread in ImportTask
+
+		importer.setOclClient(mockedOclClient);
+		importer.setImportService(importService);
+
+		// Initial update
+		importer.runTask();
+		//TODO: Wait here?
+
+		when(mockedOclClient.fetchLatestOclReleaseVersion(
+				importService.getSubscription().getUrl(),
+				importService.getSubscription().getToken()))
+				.thenReturn(actualReleaseVersion);
+
+		// TODO: Create mock response file -> "CIEL_20150614-testdata.20150622121229.tar"
+		final String actualOclResponseTarfilename = "CIEL_20150614-testdata.20150622121229.tar";
+		File actualOclResponseTarfile = new File("src/test/resources/", actualOclResponseTarfilename);
+		FileInputStream actualFileInputStream = new FileInputStream(actualOclResponseTarfile);
+
+		// Mock further response
+		when(mockedGetMethod.getResponseBodyAsStream()).thenReturn(actualFileInputStream);
+		when(mockedGetMethod.getResponseContentLength()).thenReturn(Long.valueOf(actualFileInputStream.available()));
+
+		// Last Release Update
+		importer.runTask();
+
+		//TODO Assertion
+
+	}
+
+	@Ignore("WIP - OCLM-46")
+	@Test
+	public void mockUpdate_shouldImportMockedSnapshotResponse() throws Exception {
+
+		Subscription subscription = new Subscription();
+		subscription.setUrl("http://api.openconceptlab.com/orgs/CIEL/sources/CIEL");
+		subscription.setToken("41062d8fd2bcf5eb5457988bbe2dcb5446a80a07");
+		subscription.setSubscribedToSnapshot(true);
+
+		final String filename = "CIEL_20150514-testdata-short.20150622121229.tar";
+
+		final String releaseVersion = "1.2";
+
+		//TODO see API for snapshot exportURL
+		final String exportUrl = "https://ocl-source-export-production.s3.amazonaws.com/CIEL/"
+				+ filename
+				+ "?Signature=p6C4oOtz%2Fgcom5PqXDDnFexeLfg%3D&Expires=1478508163&AWSAccessKeyId=AKIAJSVYSQTANHNWOOPQ";
+
+		//TODO: getSubscription() in ImportServiceImpl.java
+		importService.saveSubscription(subscription);
+
+		// Mock latest release version http request
+		doReturn(releaseVersion).when(mockedOclClient).fetchLatestOclReleaseVersion(
+				importService.getSubscription().getUrl(),
+				importService.getSubscription().getToken());
+
+		// Mock export url
+		doReturn(exportUrl).when(mockedOclClient).fetchExportUrl(
+				importService.getSubscription().getUrl(),
+				importService.getSubscription().getToken(),
+				releaseVersion);
+
+		doReturn(mockedGetMethod).when(mockedOclClient).executeResponse(exportUrl);
+
+		final String dateHeaderValue = "Mon, 07 Nov 2016 09:52:34 GMT";
+		Header dateHeader = new Header();
+		dateHeader.setName("Date");
+		dateHeader.setValue(dateHeaderValue);
+
+		// Mock response date header
+		when(mockedGetMethod.getStatusCode()).thenReturn(200);
+		when(mockedGetMethod.getResponseHeader("Date")).thenReturn(dateHeader);
+
+		File oclInitialResponseTarfile = new File("src/test/resources/", filename);
+		FileInputStream initialResponseFileInputStream = new FileInputStream(oclInitialResponseTarfile);
+
+		// Mock response
+		when(mockedGetMethod.getResponseBodyAsStream()).thenReturn(initialResponseFileInputStream);
+		when(mockedGetMethod.getResponseContentLength()).thenReturn(Long.valueOf(initialResponseFileInputStream.available()));
+		when(mockedGetMethod.getPath()).thenReturn(null);
+
+		doReturn(new Date()).when(mockedOclClient).parseDateFromPath(null);
+
+		//TODO Mock thread in ImportTask
+
+		importer.setOclClient(mockedOclClient);
+		importer.setImportService(importService);
+
+		// Initial update
+		importer.runTask();
+		//TODO: Wait here?
+
+		//TODO Snapshot logic mock
+		//TODO Assertion
+
+	}
 
     @Test
     public void update_shouldUpdateReleaseVersion() throws Exception {
@@ -270,6 +495,18 @@ public class UpdateServiceTest extends BaseModuleContextSensitiveTest {
 		List<ConceptName> duplicateOclNames = importService.changeDuplicateConceptNamesToIndexTerms(conceptToImport);
 		assertThat(duplicateOclNames, contains((Matcher<? super ConceptName>) hasProperty("name", is("Rubella Viêm não"))));
 	}
+
+
+    public static <T> T getTargetObject(Object proxy) {
+        if ((AopUtils.isJdkDynamicProxy(proxy))) {
+            try {
+                return (T) getTargetObject(((Advised) proxy).getTargetSource().getTarget());
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to unproxy target.", e);
+            }
+        }
+        return (T) proxy;
+    }
 
 
 }


### PR DESCRIPTION
### TODO:
- [ ] Initial update mock
- [ ] Next release version update mock
- [ ] Snapshot update mock

- [ ] Test parsing data from response filename (`OclClient`'s `parseDateFromPath()`)
- [ ] Assert whole Import object changes
- [ ] Assert DB Concept/Mappings changes 

### Notes:
- There are some API response changes, that needs to be applied in OCLM
- I couldn't finish this ticket because Threads<->Hibernate logic blows my mind; It is difficult to get subscription instance from `importService.getSubscription()` in `Importer` when testing. Run `mockUpdate_shouldImportInitialDataFromMockedResponse` for details.