### PR TITLE
OCLM-39/OCLM-49 - Support offline updates

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabActivator.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabActivator.java
@@ -10,13 +10,21 @@
 package org.openmrs.module.openconceptlab;
 
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.GlobalProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.DaemonToken;
 import org.openmrs.module.DaemonTokenAware;
 import org.openmrs.module.ModuleActivator;
+import org.openmrs.module.openconceptlab.importer.Importer;
 import org.openmrs.module.openconceptlab.scheduler.UpdateScheduler;
+import org.openmrs.util.OpenmrsUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.zip.ZipFile;
 
 /**
  * This class contains the logic that is run every time this module is either started or stopped.
@@ -41,10 +49,46 @@ public class OpenConceptLabActivator implements ModuleActivator, DaemonTokenAwar
 		if (!Context.isSessionOpen()) {
 			Context.openSession();
 		}
-			
+
+		String loadAtStartupPath = Context.getAdministrationService()
+				.getGlobalProperty(OpenConceptLabConstants.GP_OCL_LOAD_AT_STARTUP_PATH);
+		if (StringUtils.isBlank(loadAtStartupPath)) {
+			loadAtStartupPath =
+					new File(new File(new File(OpenmrsUtil.getApplicationDataDirectory(), "ocl"), "configuration"), "loadAtStartup").getAbsolutePath();
+			Context.getAdministrationService()
+					.saveGlobalProperty(
+							new GlobalProperty(OpenConceptLabConstants.GP_OCL_LOAD_AT_STARTUP_PATH, loadAtStartupPath)
+					);
+		}
+
+		File loadAtStartupDir = new File(loadAtStartupPath);
+		if (!loadAtStartupDir.exists()) {
+			loadAtStartupDir.mkdirs();
+		}
+
 		UpdateScheduler scheduler = Context.getRegisteredComponent("openconceptlab.updateScheduler", UpdateScheduler.class);
-		scheduler .scheduleUpdate();
-		
+
+		File[] files = loadAtStartupDir.listFiles();
+		if (files != null && files.length > 1) {
+			throw new IllegalStateException(
+					"There is more than one file in ocl/loadAtStartup directory\n" +
+					"Ensure that there is only one file\n" +
+					"Absolute directory path: " + loadAtStartupDir.getAbsolutePath());
+		} else if (files != null && files.length != 0) {
+			if (files[0].getName().endsWith(".zip")) {
+				try {
+					ZipFile zipFile = (new ZipFile(files[0]));
+					Importer importer = Context.getRegisteredComponent("openconceptlab.importer", Importer.class);
+					importer.setImportFile(zipFile);
+					scheduler.scheduleNow();
+				} catch (IOException e) {
+					throw new IllegalStateException("Failed to open zip file", e);
+				}
+			} else {
+				throw new IllegalStateException("File " + files[0].getName() + " must be in *.zip format");
+			}
+		}
+		scheduler.scheduleUpdate();
 		log.info("Open Concept Lab Module refreshed");
 	}
 	

--- a/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabConstants.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabConstants.java
@@ -33,4 +33,5 @@ public class OpenConceptLabConstants {
 	public static final String GP_TOKEN = MODULE_ID + ".token";
 	public static final String GP_SUBSCRIBED_TO_SNAPSHOT = MODULE_ID + ".subscribedToSnapshot";
 	public static final String GP_VALIDATION_TYPE = MODULE_ID + ".validationType";
+	public static final String GP_OCL_LOAD_AT_STARTUP_PATH = MODULE_ID + ".oclLoadAtStartupPath";
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/Utils.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/Utils.java
@@ -11,11 +11,14 @@ package org.openmrs.module.openconceptlab;
 
 import org.apache.commons.lang3.time.DateUtils;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipFile;
 
 /**
  * Contains most of the utility methods for Open Concept lab
@@ -102,4 +105,21 @@ public class Utils {
 
 		return dateFormatter.format(date) + " " + timeFormatter.format(date);
 	}
+
+	public static InputStream extractExportInputStreamFromZip(ZipFile zipfile) throws IOException {
+
+		//todo overload method with filename? is export.json ok?
+		final String fileToBeExtracted="export.json";
+
+		InputStream in;
+		try {
+			in = zipfile.getInputStream(zipfile.getEntry(fileToBeExtracted));
+		}
+		catch (IOException e) {
+			throw new IOException("Failed to load " + fileToBeExtracted + " from " + zipfile.getName(), e);
+		}
+
+		return in;
+	}
+
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/Utils.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/Utils.java
@@ -108,7 +108,6 @@ public class Utils {
 
 	public static InputStream extractExportInputStreamFromZip(ZipFile zipfile) throws IOException {
 
-		//todo overload method with filename? is export.json ok?
 		final String fileToBeExtracted="export.json";
 
 		InputStream in;

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/ImportTask.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/ImportTask.java
@@ -9,27 +9,27 @@
  */
 package org.openmrs.module.openconceptlab.importer;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.Daemon;
 import org.openmrs.module.openconceptlab.CacheService;
+import org.openmrs.module.openconceptlab.Import;
+import org.openmrs.module.openconceptlab.ImportService;
 import org.openmrs.module.openconceptlab.Item;
 import org.openmrs.module.openconceptlab.ItemState;
 import org.openmrs.module.openconceptlab.OpenConceptLabActivator;
-import org.openmrs.module.openconceptlab.Import;
-import org.openmrs.module.openconceptlab.ImportService;
 import org.openmrs.module.openconceptlab.client.OclConcept;
 import org.openmrs.module.openconceptlab.client.OclMapping;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ImportTask implements Runnable {
 	
 	private final Log log = LogFactory.getLog(getClass());
 	
-	private Saver importer;
+	private Saver saver;
 	
 	private ImportService updateService;
 	
@@ -41,8 +41,8 @@ public class ImportTask implements Runnable {
 	
 	private CacheService cacheService;
 	
-	public ImportTask(Saver importer, CacheService cacheService, ImportService updateService, Import anImport) {
-		this.importer = importer;
+	public ImportTask(Saver saver, CacheService cacheService, ImportService updateService, Import anImport) {
+		this.saver = saver;
 		this.updateService = updateService;
 		this.anImport = anImport;
 		this.cacheService = cacheService;
@@ -70,7 +70,7 @@ public class ImportTask implements Runnable {
 					for (OclConcept oclConcept : oclConcepts) {
 						Item item = null;
 						try {
-							item = importer.saveConcept(cacheService, anImport, oclConcept);
+							item = saver.saveConcept(cacheService, anImport, oclConcept);
 							log.info("Imported concept " + oclConcept);
 						}
 						catch (Throwable e) {
@@ -93,7 +93,7 @@ public class ImportTask implements Runnable {
 					for (OclMapping oclMapping : oclMappings) {
 						Item item = null;
 						try {
-							item = importer.saveMapping(cacheService, anImport, oclMapping);
+							item = saver.saveMapping(cacheService, anImport, oclMapping);
 							log.info("Imported mapping " + oclMapping);
 						}
 						catch (Throwable e) {

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -33,6 +33,7 @@
 			<bean class="org.openmrs.module.openconceptlab.ImportServiceImpl">
 				<property name="sessionFactory" ref="sessionFactory" />
 				<property name="adminService" ref="adminService" />
+				<property name="conceptService" ref="conceptService"/>
 			</bean>
 		</property>
 		<property name="preInterceptors">

--- a/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
@@ -184,7 +184,6 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 	}
 
     /*
-     * TODO:
      * These ignored tests are working fine,
      * but it takes too much time to finish them
      * since tests are downloading data from real OCL.
@@ -313,7 +312,6 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 
 		TestResources.setupDaemonToken();
 		InputStream in = TestResources.getSimpleResponseAsJsonStream();
-		importer.setInputStream(in);
 		importer.run(in);
 
 		Import lastImport = importService.getLastImport();

--- a/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
@@ -29,6 +29,7 @@ import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.*;
 
 import static org.hamcrest.Matchers.contains;
@@ -311,7 +312,9 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 		importer.setSaver(saver);
 
 		TestResources.setupDaemonToken();
-		importer.run(TestResources.getSimpleResponseAsJsonStream());
+		InputStream in = TestResources.getSimpleResponseAsJsonStream();
+		importer.setInputStream(in);
+		importer.run(in);
 
 		Import lastImport = importService.getLastImport();
 

--- a/omod/src/main/java/org/openmrs/module/openconceptlab/web/rest/resources/ImportResource.java
+++ b/omod/src/main/java/org/openmrs/module/openconceptlab/web/rest/resources/ImportResource.java
@@ -6,7 +6,6 @@ import org.openmrs.module.openconceptlab.Import;
 import org.openmrs.module.openconceptlab.ImportProgress;
 import org.openmrs.module.openconceptlab.ImportService;
 import org.openmrs.module.openconceptlab.ItemState;
-import org.openmrs.module.openconceptlab.Utils;
 import org.openmrs.module.openconceptlab.importer.Importer;
 import org.openmrs.module.openconceptlab.scheduler.UpdateScheduler;
 import org.openmrs.module.openconceptlab.web.rest.controller.OpenConceptLabRestController;
@@ -30,7 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipFile;
@@ -184,16 +182,14 @@ public class ImportResource extends DelegatingCrudResource<Import> implements Up
     @Override
     public Object upload(MultipartFile multipartFile, RequestContext requestContext) throws ResponseException, IOException {
 
-        File file = new File(multipartFile.getOriginalFilename());
+        File file = File.createTempFile("ocl", ".zip");
         multipartFile.transferTo(file);
         ZipFile zipFile = new ZipFile(file);
-        InputStream inputStream = Utils.extractExportInputStreamFromZip(zipFile);
-        file.delete();
 
         ImportService importService = getImportService();
         Importer importer = Context.getRegisteredComponent("openconceptlab.importer", Importer.class);
-        importer.setInputStream(inputStream);
 
+        importer.setImportFile(zipFile);
 
         UpdateScheduler updateScheduler = Context.getRegisteredComponent("openconceptlab.updateScheduler", UpdateScheduler.class);
         updateScheduler.scheduleNow();

--- a/owa/app/css/openconceptlab.css
+++ b/owa/app/css/openconceptlab.css
@@ -118,6 +118,22 @@ table td {
     animation: spin 2s linear infinite;
 }
 
+#loader-small {
+    width: 20px;
+    height: 20px;
+    float: right;
+    position: absolute;
+    top: 50%;
+    right: 50%;
+}
+
+.loader.ng-animate {
+    transition:0s none;
+    -webkit-transition:0s none;
+    animation: 0s none;
+    -webkit-animation: 0s none;
+}
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }

--- a/owa/app/js/home/home.html
+++ b/owa/app/js/home/home.html
@@ -1,4 +1,4 @@
-<div ng-show="!vm.subscription">
+<div ng-show="!vm.subscription" xmlns:top="http://www.w3.org/1999/xhtml" xmlns:top="http://www.w3.org/1999/xhtml">
     <div>
         <a class="button" href="#/subscription"><i class="icon-plus"></i>&nbsp;{{"configuresubscription.button" | translate}}</a>
     </div><br>
@@ -69,4 +69,29 @@
             </div>
         </fieldset>
     </div>
+
+    <fieldset ng-disabled="vm.isImporting() || vm.isUploading" style="margin-top: 15px">
+        <legend>Upload source using file</legend>
+        <form name="fileUpload">
+            <div style="overflow: hidden; margin-bottom: 5px; margin-top: 5px">
+                <div style="width: 70%; float: left">
+                    <input type="file"
+                           style="border: none"
+                           ngf-select
+                           ng-model="zipFile"
+                           name="file"
+                           accept="{{vm.allowedFormat}}"
+                           required>
+                </div>
+                <div style="position: relative">
+
+                    <button style="float: right"
+                            ng-disabled="!fileUpload.$valid || !vm.isFileCorrect(zipFile.name)"
+                            ng-click="vm.uploadZip(zipFile)">Submit</button>
+
+                    <div class="loader" id="loader-small" ng-show="vm.isUploading"></div>
+                </div>
+            </div>
+        </form>
+    </fieldset>
 </div>

--- a/owa/app/js/home/home.js
+++ b/owa/app/js/home/home.js
@@ -2,8 +2,9 @@ import angular from 'angular';
 import uiRouter from 'angular-ui-router';
 import homeComponent from './home.component.js';
 import uicommons from 'openmrs-contrib-uicommons';
+import ngFileUpload from 'ng-file-upload';
 
-let homeModule = angular.module('home', [ uiRouter, 'openmrs-contrib-uicommons'])
+let homeModule = angular.module('home', [ uiRouter, 'openmrs-contrib-uicommons', 'ngFileUpload'])
     .config(($stateProvider, $urlRouterProvider) => {
         "ngInject";
         $urlRouterProvider.otherwise('/');

--- a/owa/package.json
+++ b/owa/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "angular": "^1.5.3",
     "angular-ui-router": "^0.3.0",
-    "openmrs-contrib-uicommons": "^0.4.2"
+    "openmrs-contrib-uicommons": "^0.4.2",
+    "ng-file-upload": "^12.2.13"
   },
   "devDependencies": {
     "archiver": "^1.0.0",


### PR DESCRIPTION
### UI:
- [x] Add file update option
- [x] Show notifications when something happen
- [x] Show update progress

**Notes:**
- UI uses `"ng-file-upload": "^12.2.13"` to load file uploading component.
See https://github.com/danialfarid/ng-file-upload for details
### Backend:
- [x] File uploading via REST
- [x] Pass uploaded file to Importer
- [x] Import concepts/mappings
- [x] ~~Include a source version in deployment artifacts and load it at system startup~~ - moved to [OCLM-49](https://issues.openmrs.org/browse/OCLM-49)

**Notes:**
- File uploading by REST is done by passing file param to ImportResource, which now implements Uploadable interface.