### PR TITLE
OCLM-50 - Add module to Reference Application

### DIFF
--- a/omod/src/main/resources/apps/openConceptLabClient_app.json
+++ b/omod/src/main/resources/apps/openConceptLabClient_app.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "owa.openconceptlab",
+    "description": "Open Concept Lab Client OWA",
+    "order": 0,
+    "extensions": [
+      {
+        "id": "owa.openconceptlab.adminGroup",
+        "extensionPointId": "org.openmrs.module.adminui.adminGroups",
+        "type": "group",
+        "label": "Open Concept Lab",
+        "icon": "icon-random"
+      },
+      {
+        "id": "owa.openconceptlab.adminLink",
+        "extensionPointId": "org.openmrs.module.adminui.adminLinks",
+        "type": "link",
+        "label": "Manage OCL",
+        "url": "owa/openconceptlab/index.html",
+        "extensionParams": {
+          "group": "owa.openconceptlab.adminGroup"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
`openConceptLabClient_app.json` is used by reference application to display links to OCL Client OWA in Configure Metadata menu.

@rkorytkowski 
Please tell me which icons and labels do You want to use here