### PR TITLE
OCLM-67: Add support for importing names of type Index Term and Short

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -256,6 +256,10 @@ public class Saver {
 		for (OclConcept.Name oclName: oclConcept.getNames()) {
 			if (StringUtils.equalsIgnoreCase("Fully Specified", oclName.getNameType())) {
 				oclName.setNameType("FULLY_SPECIFIED");
+			} else if (StringUtils.equalsIgnoreCase("Index Term", oclName.getNameType())) {
+				oclName.setNameType("INDEX_TERM");
+			} else if (StringUtils.equalsIgnoreCase("Short", oclName.getNameType())) {
+				oclName.setNameType("SHORT");
 			}
 		}
 	}


### PR DESCRIPTION
### JIRA TICKET NAME:
[OCLM-67: Add support for importing names of type Index](https://issues.openmrs.org/browse/OCLM-67)

### Summary
When performing a concept import from the API, we convert the fully specified name types from the api into the formats used by OpenMRS. This is implemented for the fully specified name type, but not for the Index Term and Short name types.