### PR TITLE
OCLOMRS-870: Ensure token is sent when downloading dictionary from OCL

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java
@@ -108,14 +108,17 @@ public class OclClient {
 
 		String collectionVersion = getOclReleaseVersion(url, token);
 
-		GetMethod exportUrlGet = executeExportRequest(url, collectionVersion);
+		GetMethod exportUrlGet = executeExportRequest(url, collectionVersion, token);
 		
 		return extractResponse(exportUrlGet);
     }
 
-    public GetMethod executeExportRequest(String url, String collectionVersion) throws IOException{
+    public GetMethod executeExportRequest(String url, String collectionVersion, String token) throws IOException{
 
 		GetMethod exportUrlGet = getExportUrl(url, collectionVersion);
+		if (!StringUtils.isBlank(token)) {
+			exportUrlGet.addRequestHeader("Authorization", "Token " + token);
+		}
 
 		HttpClient client = new HttpClient();
 		client.getHttpConnectionManager().getParams().setSoTimeout(TIMEOUT_IN_MS);

--- a/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
@@ -330,7 +330,7 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 			when(mockedGetMethod.getResponseBodyAsStream()).thenReturn(response);
 			when(mockedGetMethod.getResponseContentLength()).thenReturn(Long.valueOf(response.available()));
 
-			when(mockedOclClient.executeExportRequest(importService.getSubscription().getUrl(), version)).thenReturn(mockedGetMethod);
+			when(mockedOclClient.executeExportRequest(importService.getSubscription().getUrl(), version, importService.getSubscription().getToken())).thenReturn(mockedGetMethod);
 			when(mockedOclClient.fetchOclConcepts(importService.getSubscription().getUrl(),importService.getSubscription().getToken())).thenCallRealMethod();
 			when(mockedOclClient.fetchLatestOclReleaseVersion(importService.getSubscription().getUrl(),importService.getSubscription().getToken())).thenReturn(version);
 
@@ -404,7 +404,7 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 			when(mockedGetMethod.getResponseBodyAsStream()).thenReturn(initialResponse);
 			when(mockedGetMethod.getResponseContentLength()).thenReturn(Long.valueOf(initialResponse.available()));
 
-			when(mockedOclClient.executeExportRequest(importService.getSubscription().getUrl(), initialVersion)).thenReturn(mockedGetMethod);
+			when(mockedOclClient.executeExportRequest(importService.getSubscription().getUrl(), initialVersion, importService.getSubscription().getToken())).thenReturn(mockedGetMethod);
 			when(mockedOclClient.fetchOclConcepts(importService.getSubscription().getUrl(),importService.getSubscription().getToken())).thenCallRealMethod();
 			when(mockedOclClient.fetchLatestOclReleaseVersion(importService.getSubscription().getUrl(),importService.getSubscription().getToken())).thenReturn(initialVersion);
 
@@ -438,7 +438,7 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 			when(mockedGetMethod.getResponseBodyAsStream()).thenReturn(followupResponse);
 			when(mockedGetMethod.getResponseContentLength()).thenReturn(Long.valueOf(followupResponse.available()));
 
-			when(mockedOclClient.executeExportRequest(importService.getSubscription().getUrl(), followupVersion)).thenReturn(mockedGetMethod);
+			when(mockedOclClient.executeExportRequest(importService.getSubscription().getUrl(), followupVersion, importService.getSubscription().getToken())).thenReturn(mockedGetMethod);
 			when(mockedOclClient.fetchOclConcepts(importService.getSubscription().getUrl(),importService.getSubscription().getToken(), initialVersion)).thenCallRealMethod();
 			when(mockedOclClient.fetchLatestOclReleaseVersion(importService.getSubscription().getUrl(),importService.getSubscription().getToken())).thenReturn(followupVersion);
 
@@ -502,7 +502,7 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 			when(mockedGetMethod.getResponseBodyAsStream()).thenReturn(response);
 			when(mockedGetMethod.getResponseContentLength()).thenReturn(Long.valueOf(response.available()));
 
-			when(mockedOclClient.executeExportRequest(importService.getSubscription().getUrl(), version)).thenReturn(mockedGetMethod);
+			when(mockedOclClient.executeExportRequest(importService.getSubscription().getUrl(), version, importService.getSubscription().getToken())).thenReturn(mockedGetMethod);
 			when(mockedOclClient.fetchOclConcepts(importService.getSubscription().getUrl(),importService.getSubscription().getToken())).thenCallRealMethod();
 			when(mockedOclClient.fetchLatestOclReleaseVersion(importService.getSubscription().getUrl(),importService.getSubscription().getToken())).thenReturn(version);
 


### PR DESCRIPTION
**Ticket Worked on:**

[Unable to import a private dictionary through Subscription Module.](https://issues.openmrs.org/browse/OCLOMRS-870)

**Summary of what I did:**
Since the fetchSnapshotUpdates() function is set to “Authorization” header, but when fetching the concepts we don’t, I added the `if` block [here](https://github.com/openmrs/openmrs-module-openconceptlab/blob/e0e97a049392d88250f15419633f5d563e3a98da/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java#L119) to pass the token into this function and added the ` importService.getSubscription().getToken()` to the tests of method `executeExportRequest`. to enable import a private dictionary through Subscription Module.