### PR TITLE
OCLOMRS-871:Unable to see the Set members of a concept in OpenMRS

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -362,6 +362,9 @@ public class Saver {
 					if (oclMapping.getMapType().equals(MapType.Q_AND_A)) {
 						item = updateOrAddAnswersFromOcl(update, oclMapping, fromConcept, toConcept);
 					} else {
+						if (!fromConcept.getSet()) {
+						    fromConcept.setSet(true);
+						}
 						item = updateOrAddSetMemebersFromOcl(update, oclMapping, fromConcept, toConcept);
 					}
 


### PR DESCRIPTION
**Issue worked on:**
[Unable to see the Set members of a concept in OpenMRS](https://issues.openmrs.org/browse/OCLOMRS-871)

**Summary of what I changed**
  Since we can’t set the set property on concepts correctly I  added

if (!fromConcept.getSet()) {
    fromConcept.setSet(true);
}
 inside the existing [else](https://github.com/openmrs/openmrs-module-openconceptlab/blob/e0e97a049392d88250f15419633f5d563e3a98da/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java#L365): to enable visibility of imported concept from OCL  with set members to OpenMRS via the subscription module  on the OpenMRS concepts details page. 