### PR TITLE
OCLOMRS-983:Support for to_source_name_resolved in OCL Module

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -132,8 +132,8 @@ public class OclMapping {
 		return toSourceName;
 	}
 	
-	public void setToSourceName() {
-		this.toSourceName;
+	public void setToSourceName(String toSourceName) {
+		this.toSourceName = toSourceName;
 	}
 	
 	public String getToSourceNameResolved() {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -129,6 +129,10 @@ public class OclMapping {
 	}
 	
 	public void getToSourceName(String toSourceName) {
+		return toSourceName = toSourceName;
+	}
+	
+	public void setToSourceName(String toSourceName) {
 		this.toSourceName = toSourceName;
 	}
 	
@@ -136,7 +140,7 @@ public class OclMapping {
 		return toSourceName != null ? toSourceName : toSourceNameResolved;
 	}
 	
-	public void setToSourceName(String toSourceName) {
+	public void setToSourceNameResolved(String toSourceName) {
 		this.toSourceName = toSourceName;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -129,8 +129,8 @@ public class OclMapping {
 		return toSourceName != null ? toSourceName : toSourceNameResolved;
 	}
 	
-	public void setToSourceName(String toSourceName) {
-		this.toSourceName = toSourceName;
+	public void setToSourceName(String toSourceNameResolved) {
+		this.toSourceName = toSourceNameResolved;
 	}
 	
 	public String getToConceptCode() {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -42,7 +42,7 @@ public class OclMapping {
 	private String toConceptUrl;
 	
 	@JsonProperty("to_source_name_resolved")
-	private String toSourceName;
+	private String toSourceNameResolved;
 	
 	@JsonProperty("to_concept_code")
 	private String toConceptCode;

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -44,6 +44,9 @@ public class OclMapping {
 	@JsonProperty("to_source_name_resolved")
 	private String toSourceNameResolved;
 	
+	@JsonProperty("to_source_name")
+	private String toSourceName;
+	
 	@JsonProperty("to_concept_code")
 	private String toConceptCode;
 	
@@ -125,7 +128,7 @@ public class OclMapping {
 		this.fromConceptUrl = fromConceptUrl;
 	}
 	
-	public String getToSourceName() {
+	public String getToSourceNameResolved() {
 		return toSourceName != null ? toSourceName : toSourceNameResolved;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -128,7 +128,7 @@ public class OclMapping {
 		this.fromConceptUrl = fromConceptUrl;
 	}
 	
-	public void getToSourceName() {
+	public String getToSourceName() {
 		return toSourceName;
 	}
 	

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -128,12 +128,12 @@ public class OclMapping {
 		this.fromConceptUrl = fromConceptUrl;
 	}
 	
-	public void getToSourceName(String toSourceName) {
-		return toSourceName = toSourceName;
+	public void getToSourceName() {
+		return toSourceName;
 	}
 	
-	public void setToSourceName(String toSourceName) {
-		this.toSourceName = toSourceName;
+	public void setToSourceName() {
+		this.toSourceName;
 	}
 	
 	public String getToSourceNameResolved() {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -128,12 +128,16 @@ public class OclMapping {
 		this.fromConceptUrl = fromConceptUrl;
 	}
 	
+	public void getToSourceName(String toSourceName) {
+		this.toSourceName = toSourceName;
+	}
+	
 	public String getToSourceNameResolved() {
 		return toSourceName != null ? toSourceName : toSourceNameResolved;
 	}
 	
-	public void setToSourceName(String toSourceNameResolved) {
-		this.toSourceName = toSourceNameResolved;
+	public void setToSourceName(String toSourceName) {
+		this.toSourceName = toSourceName;
 	}
 	
 	public String getToConceptCode() {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -41,7 +41,7 @@ public class OclMapping {
 	@JsonProperty("to_concept_url")
 	private String toConceptUrl;
 	
-	@JsonProperty("to_source_name")
+	@JsonProperty("to_source_name_resolved")
 	private String toSourceName;
 	
 	@JsonProperty("to_concept_code")
@@ -126,7 +126,7 @@ public class OclMapping {
 	}
 	
 	public String getToSourceName() {
-		return toSourceName;
+		return toSourceName != null ? toSourceName : toSourceNameResolved;
 	}
 	
 	public void setToSourceName(String toSourceName) {


### PR DESCRIPTION
**Issue worked on**
[Support for to_source_name_resolved in OCL Module](https://issues.openmrs.org/browse/OCLOMRS-983)

**Summary of what changed** 
I ensured the  [OclMapping](https://github.com/openmrs/openmrs-module-openconceptlab/blob/master/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java) class gets the to_source_name_resolved property and  changed the getToSourceName() function to these:

```
`public String getToSourceName() {

	return toSourceName != null ? toSourceName : toSourceNameResolved;
}`
```

