### PR TITLE
OCLOMRS-977: Update Subscription Module to support answer option order

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -56,20 +56,7 @@ public class OclMapping {
 	@JsonProperty("sort_Weight")
 	private Double sortWeight;
 	
-	@JsonIgnoreProperties(ignoreUnknown = true)
-	public static class Extras {
-	     @JsonProperty("sort_weight")
-	     private Double sortWeight;
-	}
-	
 	private Extras extras;
-	
-	public static abstract class MapType {
-		
-		public static final String Q_AND_A = "Q-AND-A";
-		
-		public static final String SET = "CONCEPT-SET";
-	}
 	
 	public String getId() {
 		return id;
@@ -190,5 +177,18 @@ public class OclMapping {
 	@Override
 	public String toString() {
 	    return new ToStringBuilder(this).append("externalId", externalId).build();
+	}
+	
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Extras {
+	     @JsonProperty("sort_weight")
+	     private Double sortWeight;
+	}
+	
+	public static final class MapType {
+		
+		public static final String Q_AND_A = "Q-AND-A";
+		
+		public static final String SET = "CONCEPT-SET";
 	}
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -53,6 +53,17 @@ public class OclMapping {
 	@JsonProperty("updated_on")
 	private Date updatedOn;
 	
+	@JsonProperty("sort_Weight")
+	private Double sortWeight;
+	
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Extras {
+	     @JsonProperty("sort_weight")
+	     private Double sortWeight;
+	}
+	
+	private Extras extras;
+	
 	public static abstract class MapType {
 		
 		public static final String Q_AND_A = "Q-AND-A";
@@ -166,6 +177,14 @@ public class OclMapping {
 
 	public void setUpdatedOn(Date updatedOn) {
 		this.updatedOn = updatedOn;
+	}
+	
+	public Extras getExtras() {
+		return extras;
+	}
+
+	public void setExtras(Extras extras) {
+		this.extras = extras;
 	}
 
 	@Override


### PR DESCRIPTION
**Issue worked on:**
[Update Subscription Module to support answer option ordering changes](https://issues.openmrs.org/browse/OCLOMRS-977)

**Summary of what I changed**

I updated the `OclMapping` class to support an` extras object` that contains a sortWeight field that contains a number. Also updated the method we use to `create or update concept answers` so that when the `extras.sortWeight` property is available we set the corresponding `ConceptAnswer's sortWeight` field to the same value.