### PR TITLE
OCLOMRS-1042: Mapping errors on import

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -329,21 +329,21 @@ public class Saver {
 					}
 				}
 
-				Item toItem = null;
-				Concept toConcept = null;
-				if (!StringUtils.isBlank(oclMapping.getToConceptUrl())) {
-					toItem = importService.getLastSuccessfulItemByUrl(oclMapping.getToConceptUrl());
-					if (toItem != null) {
-						toConcept = cacheService.getConceptByUuid(toItem.getUuid());
-					}
-
-					if (toConcept == null) {
-						throw new SavingException("Cannot create mapping to concept with URL "
-								+ oclMapping.getToConceptUrl() + ", because the concept has not been imported");
-					}
-				}
-
 				if (MapType.Q_AND_A.equals(oclMapping.getMapType()) || MapType.SET.equals(oclMapping.getMapType())) {
+					Item toItem = null;
+					Concept toConcept = null;
+					if (!StringUtils.isBlank(oclMapping.getToConceptUrl())) {
+						toItem = importService.getLastSuccessfulItemByUrl(oclMapping.getToConceptUrl());
+						if (toItem != null) {
+							toConcept = cacheService.getConceptByUuid(toItem.getUuid());
+						}
+
+						if (toConcept == null) {
+							throw new SavingException("Cannot create mapping to concept with URL "
+									+ oclMapping.getToConceptUrl() + ", because the concept has not been imported");
+						}
+					}
+
 					if (oclMapping.getMapType().equals(MapType.Q_AND_A)) {
 						item = updateOrAddAnswersFromOcl(update, oclMapping, fromConcept, toConcept);
 					} else {

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -19,9 +19,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -824,6 +822,56 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
 		
 		assertTrue(saver.isMappingUpToDate(item, oclMapping));
+	}
+
+	@Test
+	public void saveMapping_ShouldNotSaveReferenceConceptIfMappingNotQnAorSet() {
+
+		Import update = importService.getLastImport();
+
+		OclConcept oclConcept = newOclConcept();
+
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, oclConcept));
+
+		OclMapping oclMapping = new OclMapping();
+		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+
+		oclMapping.setMapType("SAME-AS");
+		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
+		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/100002/");
+		oclMapping.setToSourceName("CIELTEST");
+		oclMapping.setToConceptCode("100002");
+
+		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+
+		Concept toConcept = conceptService.getConcept(100002);
+		assertEquals(null, toConcept);
+
+	}
+
+	@Test
+	public void saveMapping_ShouldSaveMappingIfNotQnAorSetAndReferencedConceptDoesNotExist() {
+
+		Import update = importService.getLastImport();
+
+		OclConcept oclConcept = newOclConcept();
+
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, oclConcept));
+
+		OclMapping oclMapping = new OclMapping();
+		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+
+		oclMapping.setMapType("SAME-AS");
+		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
+		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/100002/");
+		oclMapping.setToSourceName("CIELTEST");
+		oclMapping.setToConceptCode("100002");
+
+		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+
+		Concept fromConcept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		assertThat(fromConcept.getConceptMappings().size(), is(1));
+
 	}
 
 	public OclConcept newOclConcept() {

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -19,7 +19,10 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;


### PR DESCRIPTION
Validation checks for referenced Concepts will now only happen if the Mapping is `Q-And-A` or `Set`