### PR TITLE
OCLOMRS-1008: Use existing mapped concepts instead of creating new ones

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,11 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: ${{ matrix.java-version }}
-      - name: Install dependencies
-        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version --file pom.xml
-      - name: Build with Maven
-        run: mvn test --batch-mode --file pom.xml
+      - name: Run Maven Build
+        run: mvn clean install --batch-mode --show-version --file pom.xml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,13 +26,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Install dependencies
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version --file pom.xml
       - name: Build with Maven

--- a/api/src/main/java/org/openmrs/module/openconceptlab/CacheService.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/CacheService.java
@@ -130,11 +130,11 @@ public class CacheService {
 		}
     }
 	
-	public Concept getConceptByMapping(String source, String code) {
+	public Concept getConceptWithSameAsMapping(String source, String code) {
 		String cacheKey = source + ":" + code;
 		Concept concept = concepts.get(cacheKey);
 		if (concept == null) {
-			concept = oclConceptService.getDuplicateConceptByMapping(code, source);
+			concept = oclConceptService.getConceptWithSameAsMapping(code, source);
 			if (concept != null) {
 				concepts.put(cacheKey, concept);
 			}

--- a/api/src/main/java/org/openmrs/module/openconceptlab/CacheService.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/CacheService.java
@@ -23,9 +23,12 @@ import org.openmrs.api.ConceptService;
 public class CacheService {
 
 	ConceptService conceptService;
+	
+	OclConceptService oclConceptService;
 
-	public CacheService(ConceptService conceptService) {
+	public CacheService(ConceptService conceptService, OclConceptService oclConceptService) {
 		this.conceptService = conceptService;
+		this.oclConceptService = oclConceptService;
 	}
 
 	Map<String, ConceptDatatype> conceptDatatypes = new ConcurrentHashMap<String, ConceptDatatype>();
@@ -126,4 +129,17 @@ public class CacheService {
 			return concept;
 		}
     }
+	
+	public Concept getConceptByMapping(String source, String code) {
+		String cacheKey = source + ":" + code;
+		Concept concept = concepts.get(cacheKey);
+		if (concept == null) {
+			concept = oclConceptService.getDuplicateConceptByMapping(code, source);
+			if (concept != null) {
+				concepts.put(cacheKey, concept);
+			}
+		}
+		
+		return concept;
+	}
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/ImportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ImportServiceImpl.java
@@ -45,6 +45,8 @@ public class ImportServiceImpl implements ImportService {
 	AdministrationService adminService;
 
 	ConceptService conceptService;
+	
+	OclConceptService oclConceptService;
 
 	public void setSessionFactory(DbSessionFactory sessionFactory) {
 	    this.sessionFactory = sessionFactory;
@@ -56,6 +58,10 @@ public class ImportServiceImpl implements ImportService {
 
 	public void setConceptService(ConceptService conceptService) {
 		this.conceptService = conceptService;
+	}
+	
+	public void setOclConceptService(OclConceptService oclConceptService) {
+		this.oclConceptService = oclConceptService;
 	}
 
 	/**
@@ -281,7 +287,7 @@ public class ImportServiceImpl implements ImportService {
 
 	@Override
 	public Item getLastSuccessfulItemByUrl(String url) {
-		return getLastSuccessfulItemByUrl(url, new CacheService(conceptService));
+		return getLastSuccessfulItemByUrl(url, new CacheService(conceptService, oclConceptService));
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/openconceptlab/ItemState.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ItemState.java
@@ -12,5 +12,5 @@ package org.openmrs.module.openconceptlab;
 
 public enum ItemState {
 	
-	ADDED, UPDATED, RETIRED, UNRETIRED, ERROR, IGNORED_ERROR, UP_TO_DATE;
+	ADDED, UPDATED, RETIRED, UNRETIRED, ERROR, IGNORED_ERROR, UP_TO_DATE, DUPLICATE
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/OclConceptService.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OclConceptService.java
@@ -12,12 +12,12 @@ public interface OclConceptService {
 	 * which returns concepts that are marked as the "SAME-AS" an existing concept
 	 *
 	 * @param source the name of the source to check
-	 * @param conceptId the identifier of the concept
+	 * @param code the identifier of the concept
 	 * @return the concept that is semantically the same as the requested concept or null if
 	 *  one couldn't be found.
 	 */
 	@Transactional(readOnly = true)
 	@Authorized(PrivilegeConstants.VIEW_CONCEPTS)
-	Concept getDuplicateConceptByMapping(String conceptId, String source);
+	Concept getConceptWithSameAsMapping(String code, String source);
 	
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/OclConceptService.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OclConceptService.java
@@ -1,0 +1,23 @@
+package org.openmrs.module.openconceptlab;
+
+import org.openmrs.Concept;
+import org.openmrs.annotation.Authorized;
+import org.openmrs.util.PrivilegeConstants;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface OclConceptService {
+	
+	/**
+	 * A version of {@link org.openmrs.api.ConceptService#getConceptByMapping(String, String)}
+	 * which returns concepts that are marked as the "SAME-AS" an existing concept
+	 *
+	 * @param source the name of the source to check
+	 * @param conceptId the identifier of the concept
+	 * @return the concept that is semantically the same as the requested concept or null if
+	 *  one couldn't be found.
+	 */
+	@Transactional(readOnly = true)
+	@Authorized(PrivilegeConstants.VIEW_CONCEPTS)
+	Concept getDuplicateConceptByMapping(String conceptId, String source);
+	
+}

--- a/api/src/main/java/org/openmrs/module/openconceptlab/OclConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OclConceptServiceImpl.java
@@ -1,0 +1,51 @@
+package org.openmrs.module.openconceptlab;
+
+import java.util.List;
+
+import org.openmrs.Concept;
+import org.openmrs.api.APIException;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
+import org.openmrs.api.impl.BaseOpenmrsService;
+
+public class OclConceptServiceImpl extends BaseOpenmrsService implements OclConceptService {
+	
+	private DbSessionFactory dbSessionFactory;
+	
+	@Override
+	public Concept getDuplicateConceptByMapping(String conceptId, String source) {
+		@SuppressWarnings("unchecked")
+		List<Concept> concepts = dbSessionFactory.getCurrentSession().createQuery(
+						"select c "
+								+ "from ConceptMap as cm "
+								+ "join cm.concept as c "
+								+ "join cm.conceptReferenceTerm as crt "
+								+ "where crt.conceptSource.name = :source "
+								+ "and crt.code = :code "
+								+ "and upper(cm.conceptMapType.name) = 'SAME-AS' "
+								+ "and c.retired = false "
+								+ "and crt.retired = false")
+				.setParameter("code", conceptId)
+				.setParameter("source", source)
+				.list();
+		
+		
+		
+		if (concepts == null) {
+			return null;
+		}
+		
+		if (concepts.isEmpty()) {
+			return null;
+		}
+		
+		if (concepts.size() > 1) {
+			throw new APIException("Multiple non-retired concepts found for mapping " + conceptId + " from source " + source);
+		}
+		
+		return concepts.get(0);
+	}
+	
+	public void setDbSessionFactory(DbSessionFactory dbSessionFactory) {
+		this.dbSessionFactory = dbSessionFactory;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/openconceptlab/OclConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OclConceptServiceImpl.java
@@ -12,7 +12,7 @@ public class OclConceptServiceImpl extends BaseOpenmrsService implements OclConc
 	private DbSessionFactory dbSessionFactory;
 	
 	@Override
-	public Concept getDuplicateConceptByMapping(String conceptId, String source) {
+	public Concept getConceptWithSameAsMapping(String code, String source) {
 		@SuppressWarnings("unchecked")
 		List<Concept> concepts = dbSessionFactory.getCurrentSession().createQuery(
 						"select c "
@@ -24,7 +24,7 @@ public class OclConceptServiceImpl extends BaseOpenmrsService implements OclConc
 								+ "and upper(cm.conceptMapType.name) = 'SAME-AS' "
 								+ "and c.retired = false "
 								+ "and crt.retired = false")
-				.setParameter("code", conceptId)
+				.setParameter("code", code)
 				.setParameter("source", source)
 				.list();
 		
@@ -39,7 +39,7 @@ public class OclConceptServiceImpl extends BaseOpenmrsService implements OclConc
 		}
 		
 		if (concepts.size() > 1) {
-			throw new APIException("Multiple non-retired concepts found for mapping " + conceptId + " from source " + source);
+			throw new APIException("Multiple non-retired concepts found for mapping " + code + " from source " + source);
 		}
 		
 		return concepts.get(0);

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -35,8 +35,14 @@ public class OclMapping {
 	@JsonProperty("from_source_url")
 	private String fromSourceUrl;
 	
+	@JsonProperty("from_source_name")
+	private String fromSourceName;
+	
 	@JsonProperty("from_concept_url")
 	private String fromConceptUrl;
+	
+	@JsonProperty("from_concept_code")
+	private String fromConceptCode;
 	
 	@JsonProperty("to_concept_url")
 	private String toConceptUrl;
@@ -116,12 +122,28 @@ public class OclMapping {
 		this.fromSourceUrl = fromSourceUrl;
 	}
 	
+	public String getFromSourceName() {
+		return fromSourceName;
+	}
+	
+	public void setFromSourceName(String fromSourceName) {
+		this.fromSourceName = fromSourceName;
+	}
+	
 	public String getFromConceptUrl() {
 		return fromConceptUrl;
 	}
 	
 	public void setFromConceptUrl(String fromConceptUrl) {
 		this.fromConceptUrl = fromConceptUrl;
+	}
+	
+	public String getFromConceptCode() {
+		return fromConceptCode;
+	}
+	
+	public void setFromConceptCode(String fromConceptCode) {
+		this.fromConceptCode = fromConceptCode;
 	}
 	
 	public String getToSourceName() {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Importer.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Importer.java
@@ -24,6 +24,7 @@ import org.openmrs.module.openconceptlab.Import;
 import org.openmrs.module.openconceptlab.ImportProgress;
 import org.openmrs.module.openconceptlab.ImportService;
 import org.openmrs.module.openconceptlab.ItemState;
+import org.openmrs.module.openconceptlab.OclConceptService;
 import org.openmrs.module.openconceptlab.OpenConceptLabActivator;
 import org.openmrs.module.openconceptlab.OpenConceptLabConstants;
 import org.openmrs.module.openconceptlab.Subscription;
@@ -64,6 +65,8 @@ public class Importer implements Runnable {
 	private ImportService importService;
 
 	private ConceptService conceptService;
+	
+	private OclConceptService oclConceptService;
 
 	private OclClient oclClient;
 
@@ -87,6 +90,10 @@ public class Importer implements Runnable {
 
     public void setConceptService(ConceptService conceptService) {
 	    this.conceptService = conceptService;
+    }
+    
+    public void setOclConceptService(OclConceptService oclConceptService) {
+		this.oclConceptService = oclConceptService;
     }
 
     public void setOclClient(OclClient oclClient) {
@@ -345,7 +352,7 @@ public class Importer implements Runnable {
 			oclConcepts.add(oclConcept);
 
 			if (oclConcepts.size() >= BATCH_SIZE) {
-				ImportTask importTask = new ImportTask(saver, new CacheService(conceptService), importService,
+				ImportTask importTask = new ImportTask(saver, new CacheService(conceptService, oclConceptService), importService,
 						anImport);
 				importTask.setOclConcepts(new ArrayList<>(oclConcepts));
 
@@ -356,7 +363,7 @@ public class Importer implements Runnable {
 		}
 
 		if (oclConcepts.size() != 0) {
-			ImportTask importTask = new ImportTask(saver, new CacheService(conceptService), importService, anImport);
+			ImportTask importTask = new ImportTask(saver, new CacheService(conceptService, oclConceptService), importService, anImport);
 			importTask.setOclConcepts(oclConcepts);
 
 			runner.execute(importTask);
@@ -388,7 +395,7 @@ public class Importer implements Runnable {
 			oclMappings.add(oclMapping);
 
 			if (oclMappings.size() >= BATCH_SIZE) {
-				ImportTask importTask = new ImportTask(saver, new CacheService(conceptService), importService,
+				ImportTask importTask = new ImportTask(saver, new CacheService(conceptService, oclConceptService), importService,
 						anImport);
 				importTask.setOclMappings(new ArrayList<>(oclMappings));
 
@@ -399,7 +406,7 @@ public class Importer implements Runnable {
 		}
 
 		if (oclMappings.size() != 0) {
-			ImportTask importTask = new ImportTask(saver, new CacheService(conceptService), importService, anImport);
+			ImportTask importTask = new ImportTask(saver, new CacheService(conceptService, oclConceptService), importService, anImport);
 			importTask.setOclMappings(oclMappings);
 
 			runner.execute(importTask);

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -91,8 +91,13 @@ public class Saver {
 		
 		// if a mapping for this concept already exists and it is not
 		if (item == null && oclConcept.getSource() != null && oclConcept.getId() != null) {
-			if (cacheService.getConceptWithSameAsMapping(oclConcept.getSource(), oclConcept.getId()) != null) {
-				return new Item(thisImport, oclConcept, ItemState.DUPLICATE);
+			Concept sameAsConcept = cacheService.getConceptWithSameAsMapping(oclConcept.getSource(), oclConcept.getId());
+			if (sameAsConcept != null) {
+				Item result = new Item(thisImport, oclConcept, ItemState.DUPLICATE);
+				result.setErrorMessage(String.format(
+						"Concept %s:%s was skipped as concept %s is mapped SAME-AS %1$s:%2$s",
+						oclConcept.getSource(), oclConcept.getId(), sameAsConcept.getName(Context.getLocale())));
+				return result;
 			}
 		}
 

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -89,9 +89,10 @@ public class Saver {
 			return new Item(thisImport, oclConcept, ItemState.UP_TO_DATE);
 		}
 		
-		if (oclConcept.getSource() != null && oclConcept.getId() != null) {
-			if (cacheService.getConceptByMapping(oclConcept.getSource(), oclConcept.getId()) != null) {
-				return new Item(thisImport, oclConcept, ItemState.UP_TO_DATE);
+		// if a mapping for this concept already exists and it is not
+		if (item == null && oclConcept.getSource() != null && oclConcept.getId() != null) {
+			if (cacheService.getConceptWithSameAsMapping(oclConcept.getSource(), oclConcept.getId()) != null) {
+				return new Item(thisImport, oclConcept, ItemState.DUPLICATE);
 			}
 		}
 
@@ -352,7 +353,7 @@ public class Saver {
 					if (fromConcept == null) {
 						String source = oclMapping.getFromSourceName();
 						String code = oclMapping.getFromConceptCode();
-						fromConcept = cacheService.getConceptByMapping(source, code);
+						fromConcept = cacheService.getConceptWithSameAsMapping(source, code);
 					}
 
 					if (fromConcept == null) {
@@ -378,7 +379,7 @@ public class Saver {
 						if (toConcept == null) {
 							String source = oclMapping.getToSourceName();
 							String code = oclMapping.getToConceptCode();
-							toConcept = cacheService.getConceptByMapping(source, code);
+							toConcept = cacheService.getConceptWithSameAsMapping(source, code);
 						}
 
 						if (toConcept == null) {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -88,6 +88,12 @@ public class Saver {
 		if (item != null && item.getVersionUrl().equals(oclConcept.getVersionUrl())) {
 			return new Item(thisImport, oclConcept, ItemState.UP_TO_DATE);
 		}
+		
+		if (oclConcept.getSource() != null && oclConcept.getId() != null) {
+			if (cacheService.getConceptByMapping(oclConcept.getSource(), oclConcept.getId()) != null) {
+				return new Item(thisImport, oclConcept, ItemState.UP_TO_DATE);
+			}
+		}
 
 		Concept concept;
 		try {
@@ -169,6 +175,7 @@ public class Saver {
 		if (oclConcept.getExternalId() != null) {
 			concept = cacheService.getConceptByUuid(oclConcept.getExternalId());
 		}
+		
 		if (concept == null) {
 			if (datatype.getUuid().equals(ConceptDatatype.NUMERIC_UUID)) {
 				concept = new ConceptNumeric();
@@ -341,6 +348,12 @@ public class Saver {
 					if (fromItem != null) {
 						fromConcept = cacheService.getConceptByUuid(fromItem.getUuid());
 					}
+					
+					if (fromConcept == null) {
+						String source = oclMapping.getFromSourceName();
+						String code = oclMapping.getFromConceptCode();
+						fromConcept = cacheService.getConceptByMapping(source, code);
+					}
 
 					if (fromConcept == null) {
 						throw new SavingException("Cannot create mapping from concept with URL " + oclMapping.getFromConceptUrl()
@@ -360,6 +373,12 @@ public class Saver {
 						toItem = importService.getLastSuccessfulItemByUrl(oclMapping.getToConceptUrl());
 						if (toItem != null) {
 							toConcept = cacheService.getConceptByUuid(toItem.getUuid());
+						}
+						
+						if (toConcept == null) {
+							String source = oclMapping.getToSourceName();
+							String code = oclMapping.getToConceptCode();
+							toConcept = cacheService.getConceptByMapping(source, code);
 						}
 
 						if (toConcept == null) {

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -1,22 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:jee="http://www.springframework.org/schema/jee" xmlns:tx="http://www.springframework.org/schema/tx"
-	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:util="http://www.springframework.org/schema/util"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
   		    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-  		    http://www.springframework.org/schema/context
-  		    http://www.springframework.org/schema/context/spring-context-3.0.xsd
-  		    http://www.springframework.org/schema/jee
-  		    http://www.springframework.org/schema/jee/spring-jee-3.0.xsd
-  		    http://www.springframework.org/schema/tx
-  		    http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-  		    http://www.springframework.org/schema/aop
-  		    http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
-  		    http://www.springframework.org/schema/util
-  		    http://www.springframework.org/schema/util/spring-util-3.0.xsd
   		    http://www.springframework.org/schema/task
   		    http://www.springframework.org/schema/task/spring-task-3.0.xsd">
 
@@ -26,24 +13,49 @@
 	
 	<bean id="openconceptlab.importService"
 		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
-		<property name="transactionManager">
-			<ref bean="transactionManager" />
-		</property>
+		<property name="transactionManager" ref="transactionManager"/>
 		<property name="target">
 			<bean class="org.openmrs.module.openconceptlab.ImportServiceImpl">
 				<property name="sessionFactory" ref="dbSessionFactory" />
 				<property name="adminService" ref="adminService" />
 				<property name="conceptService" ref="conceptService"/>
+				<property name="oclConceptService" ref="openconceptlab.conceptService" />
 			</bean>
 		</property>
-		<property name="preInterceptors">
-			<ref bean="serviceInterceptors" />
-		</property>
-		<property name="transactionAttributeSource">
-			<ref bean="transactionAttributeSource" />
+		<property name="preInterceptors" ref="serviceInterceptors"/>
+		<property name="transactionAttributeSource" ref="transactionAttributeSource"/>
+	</bean>
+
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list>
+				<value>org.openmrs.module.openconceptlab.ImportService</value>
+				<ref bean="openconceptlab.importService"/>
+			</list>
 		</property>
 	</bean>
-	
+
+	<bean id="openconceptlab.conceptService"
+		  class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager" ref="transactionManager"/>
+		<property name="target">
+			<bean class="org.openmrs.module.openconceptlab.OclConceptServiceImpl">
+				<property name="dbSessionFactory" ref="dbSessionFactory" />
+			</bean>
+		</property>
+		<property name="preInterceptors" ref="serviceInterceptors"/>
+		<property name="transactionAttributeSource" ref="transactionAttributeSource"/>
+	</bean>
+
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list>
+				<value>org.openmrs.module.openconceptlab.OclConceptService</value>
+				<ref bean="openconceptlab.conceptService"/>
+			</list>
+		</property>
+	</bean>
+
 	<bean id="openconceptlab.oclClient" class="org.openmrs.module.openconceptlab.client.OclClient" />
 	
 	<bean id="openconceptlab.saver" class="org.openmrs.module.openconceptlab.importer.Saver">
@@ -54,6 +66,7 @@
 	<bean id="openconceptlab.importer" class="org.openmrs.module.openconceptlab.importer.Importer">
 		<property name="importService" ref="openconceptlab.importService" />
 		<property name="conceptService" ref="conceptService" />
+		<property name="oclConceptService" ref="openconceptlab.conceptService" />
 		<property name="oclClient" ref="openconceptlab.oclClient" />
 		<property name="saver" ref="openconceptlab.saver" />
 	</bean>
@@ -62,14 +75,5 @@
 		<property name="scheduler" ref="openconceptlab.scheduler"/>
 		<property name="importer" ref="openconceptlab.importer" />
 		<property name="importService" ref="openconceptlab.importService" />
-	</bean>
-	
-	<bean parent="serviceContext">
-		<property name="moduleService">
-			<list>
-				<value>org.openmrs.module.openconceptlab.ImportService</value>
-				<ref bean="openconceptlab.importService"/>
-			</list>
-		</property>
 	</bean>
 </beans>

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -134,7 +134,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importConcept_shouldSaveNewNumericConcept() throws Exception {
 		OclConcept oclConcept = newOclNumericConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImportedConceptNumeric(oclConcept);
 	}
 

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -610,7 +610,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	@Test
-	public void saveConcept_shouldNotSaveConceptIfDuplicateMappingAlreadyExists() {
+	public void saveConcept_shouldNotSaveConceptIfSameAsMappingAlreadyExists() {
 		Import update = importService.getLastImport();
 		
 		OclConcept oclConcept = newOclConcept();
@@ -634,6 +634,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		
 		String newUuid = UUID.randomUUID().toString();
 		OclConcept duplicateConcept = newOclConcept();
+		duplicateConcept.setUrl("https://api.openconceptlab.org/orgs/CIEL/sources/CIEL/concepts/1066/");
 		duplicateConcept.setExternalId(newUuid);
 		duplicateConcept.setSource("CIEL");
 		duplicateConcept.setSourceUrl("https://api.openconceptlab.org/orgs/CIEL/sources/CIEL/");
@@ -642,7 +643,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		
 		Item result = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, duplicateConcept);
 		
-		assertThat(result.getState(), is(ItemState.UP_TO_DATE));
+		assertThat(result.getState(), is(ItemState.DUPLICATE));
 		assertThat(conceptService.getConceptByUuid(newUuid), nullValue());
 	}
 

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -63,6 +64,7 @@ import org.openmrs.module.openconceptlab.Import;
 import org.openmrs.module.openconceptlab.ImportService;
 import org.openmrs.module.openconceptlab.Item;
 import org.openmrs.module.openconceptlab.ItemState;
+import org.openmrs.module.openconceptlab.OclConceptService;
 import org.openmrs.module.openconceptlab.Subscription;
 import org.openmrs.module.openconceptlab.ValidationType;
 import org.openmrs.module.openconceptlab.client.OclConcept;
@@ -83,6 +85,10 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Autowired
 	@Qualifier("conceptService")
 	ConceptService conceptService;
+	
+	@Autowired
+	@Qualifier("openconceptlab.conceptService")
+	OclConceptService oclConceptService;
 
 	@Autowired @Qualifier("openconceptlab.importService")
 	ImportService importService;
@@ -121,7 +127,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importConcept_shouldSaveNewConcept() throws Exception {
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 	}
 
@@ -139,7 +145,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importConcept_shouldAddNewNamesToConcept() throws Exception {
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		Name thirdName = new Name();
 		thirdName.setExternalId("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
@@ -152,7 +158,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Name fourthName = newFourthName();
 		oclConcept.getNames().add(fourthName);
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 	}
 
@@ -173,7 +179,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importConcept_shouldUpdateNameTypeInConcept() throws Exception {
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		for (Name name : oclConcept.getNames()) {
 			if (name.getNameType() == null) {
@@ -181,7 +187,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 			}
 		}
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 	}
 
@@ -192,13 +198,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importConcept_shouldUpdateNamesWithDifferentUuids() throws Exception {
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		for (Name name : oclConcept.getNames()) {
 			name.setExternalId(UUID.randomUUID().toString());
 		}
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 
 		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
@@ -222,7 +228,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importConcept_shouldUpdateDatatype() throws Exception {
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		String initialDatatype = oclConcept.getDatatype();
 
@@ -231,7 +237,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertFalse(initialDatatype.equals(updatedDatatype));
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 	}
 
@@ -242,7 +248,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAcceptNoneDatatype() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		oclConcept.setDatatype("None");
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		assertThat(oclConcept.getDatatype(), equalTo("N/A"));
 
@@ -256,7 +262,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAcceptFullySpecifiedNameType() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		oclConcept.getNames().get(0).setNameType("Fully Specified");
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		assertThat(oclConcept.getNames().get(0).getNameType(), equalTo("FULLY_SPECIFIED"));
 
@@ -270,7 +276,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importConcept_shouldUpdateConceptClass() throws Exception {
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		String initialConceptClass = oclConcept.getConceptClass();
 
@@ -279,7 +285,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertFalse(initialConceptClass.equals(updatedConceptClass));
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 	}
 
@@ -292,7 +298,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		OclConcept oclConcept = newOclConcept();
 		Name fourthName = newFourthName();
 		oclConcept.getNames().add(fourthName);
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		List<Name> voided = new ArrayList<OclConcept.Name>();
 		for (Iterator<Name> it = oclConcept.getNames().iterator(); it.hasNext();) {
@@ -304,7 +310,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		}
 		assertThat(voided, is(not(empty())));
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		Concept concept = assertImported(oclConcept);
 
 		Collection<ConceptName> nonVoidedNames = concept.getNames(false);
@@ -321,14 +327,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAddNewDescriptionsToConcept() throws Exception {
 
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		Description desc1 = new Description();
 		desc1.setDescription("test oclConceptDescription");
 		desc1.setLocale(Context.getLocale());
 		oclConcept.getDescriptions().add(desc1);
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		assertImported(oclConcept);
 
@@ -342,7 +348,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldVoidDescriptionsFromConcept() throws Exception {
 
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		Description desc1 = new Description();
 		desc1.setExternalId("7cc35481-ce72-4615-b857-a944b25e9c43");
@@ -350,7 +356,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		desc1.setLocale(Context.getLocale());
 		oclConcept.getDescriptions().add(desc1);
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		Concept concept = assertImported(oclConcept);
 
 		//cloning object to save state of descriptions after importing again
@@ -369,7 +375,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(voided, is(not(empty())));
 
 		//at this point without cloning object original desc collecion is lost
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		concept = assertImported(oclConcept);
 
 		final Collection<ConceptDescription> remainingDescriptions = concept.getDescriptions();
@@ -403,11 +409,11 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldRetireConcept() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		assertFalse(oclConcept.isRetired());
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		oclConcept.setRetired(true);
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		Concept concept = assertImported(oclConcept);
 		assertTrue(concept.isRetired());
@@ -423,11 +429,11 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		OclConcept oclConcept = newOclConcept();
 		oclConcept.setRetired(true);
 		assertTrue(oclConcept.isRetired());
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		oclConcept.setRetired(false);
 
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		Concept concept = assertImported(oclConcept);
 		assertFalse(concept.isRetired());
@@ -445,7 +451,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		OclConcept concept = newOclConcept();
 		concept.setConceptClass("Some missing concept class");
 
-		saver.saveConcept(new CacheService(conceptService), update, concept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept);
 
 		ConceptClass conceptClass = conceptService.getConceptClassByName(concept.getConceptClass());
 		assertThat(conceptClass, notNullValue());
@@ -458,11 +464,11 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importConcept_shouldFailIfConceptClassMissing() throws Exception {
 		OclConcept oclConcept = newOclConcept();
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 
 		oclConcept.setConceptClass(null);
 		exception.expect(ImportException.class);
-		saver.saveConcept(new CacheService(conceptService), anImport, oclConcept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 	}
 
 	/**
@@ -478,7 +484,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		exception.expect(ImportException.class);
 		exception.expectMessage("Cannot create concept /orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
-		saver.saveConcept(new CacheService(conceptService), update, concept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept);
 	}
 
 	/**
@@ -499,7 +505,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		polishName.setLocalePreferred(true);
 		concept.getNames().add(polishName);
 
-		saver.saveConcept(new CacheService(conceptService), update, concept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept);
 
 		OclConcept conceptWithSynonym = newOtherOclConcept();
 		Name otherPolishName = new Name();
@@ -509,7 +515,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		otherPolishName.setLocalePreferred(true);
 		conceptWithSynonym.getNames().add(otherPolishName);
 
-		saver.saveConcept(new CacheService(conceptService), update, conceptWithSynonym);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, conceptWithSynonym);
 
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		Concept importedConceptWithIndexTerm = conceptService.getConceptByUuid(conceptWithSynonym.getExternalId());
@@ -529,13 +535,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldUpdateConceptIfVersionUrlChanged() throws Exception {
 		Import update = importService.getLastImport();
 		OclConcept concept = newOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, concept));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept));
 		
 		OclConcept updateConcept = newOclConcept();
 		updateConcept.setVersionUrl(newOtherOclConcept().getVersionUrl());
 		updateConcept.setDatatype("Document");
 		
-		Item item = saver.saveConcept(new CacheService(conceptService), update, updateConcept);
+		Item item = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, updateConcept);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UPDATED)));
 		
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
@@ -552,10 +558,10 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		OclConcept concept = newOclConcept();
 		OclConcept updateConcept = newOclConcept();
 			
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, concept));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept));
 		
 		updateConcept.setDatatype("Document");		
-		Item item = saver.saveConcept(new CacheService(conceptService), update, updateConcept);
+		Item item = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, updateConcept);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UP_TO_DATE)));
 		
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
@@ -580,7 +586,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		polishName.setLocalePreferred(true);
 		concept.getNames().add(polishName);
 
-		saver.saveConcept(new CacheService(conceptService), update, concept);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept);
 
 		OclConcept conceptWithSynonym = newOtherOclConcept();
 		Name otherPolishName = new Name();
@@ -591,7 +597,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		otherPolishName.setLocalePreferred(true);
 		conceptWithSynonym.getNames().add(otherPolishName);
 
-		saver.saveConcept(new CacheService(conceptService), update, conceptWithSynonym);
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, conceptWithSynonym);
 
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		Concept importedConceptWithIndexTerm = conceptService.getConceptByUuid(conceptWithSynonym.getExternalId());
@@ -602,16 +608,53 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(importedConceptWithIndexTerm.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
 			hasProperty("name", equalTo("Nazwa")))));
 	}
+	
+	@Test
+	public void saveConcept_shouldNotSaveConceptIfDuplicateMappingAlreadyExists() {
+		Import update = importService.getLastImport();
+		
+		OclConcept oclConcept = newOclConcept();
+		oclConcept.setSource("CIEL");
+		oclConcept.setSourceUrl("https://api.openconceptlab.org/orgs/CIEL/sources/CIEL/");
+		oclConcept.setId("1066");
+		
+		Item initialConcept = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+		
+		importService.saveItem(initialConcept);
+		
+		OclMapping oclMapping = new OclMapping();
+		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+		
+		oclMapping.setMapType("SAME-AS");
+		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
+		oclMapping.setToSourceName("CIEL");
+		oclMapping.setToConceptCode("1066");
+		
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
+		
+		String newUuid = UUID.randomUUID().toString();
+		OclConcept duplicateConcept = newOclConcept();
+		duplicateConcept.setExternalId(newUuid);
+		duplicateConcept.setSource("CIEL");
+		duplicateConcept.setSourceUrl("https://api.openconceptlab.org/orgs/CIEL/sources/CIEL/");
+		duplicateConcept.setId("1066");
+		duplicateConcept.setVersionUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/e87c48fd962fe4583f3efd/");
+		
+		Item result = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, duplicateConcept);
+		
+		assertThat(result.getState(), is(ItemState.UP_TO_DATE));
+		assertThat(conceptService.getConceptByUuid(newUuid), nullValue());
+	}
 
 	@Test
 	public void importMapping_shouldAddConceptAnswer() throws Exception {
 		Import update = importService.getLastImport();
 
 		OclConcept question = newOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, question));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, question));
 
 		OclConcept answer = newOtherOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, answer));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, answer));
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
@@ -620,7 +663,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept questionConcept = conceptService.getConceptByUuid(question.getExternalId());
 		Concept answerConcept = conceptService.getConceptByUuid(answer.getExternalId());
@@ -633,10 +676,10 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 
 		OclConcept question = newOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, question));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, question));
 
 		OclConcept answer = newOtherOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, answer));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, answer));
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
@@ -645,7 +688,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setExtras(newOclMappingExtras(356.0));
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept questionConcept = conceptService.getConceptByUuid(question.getExternalId());
 		Concept answerConcept = conceptService.getConceptByUuid(answer.getExternalId());
@@ -668,7 +711,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setRetired(true);
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept questionConcept = conceptService.getConceptByUuid("6c1bbb30-55f6-11e4-8ed6-0800200c9a66");
 
@@ -694,7 +737,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setExtras(newOclMappingExtras(15.0));
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		answers = answersForConcept(questionConcept, answerConcept);
 		assertThat(answers.size(), is(1));
 		assertThat(answers.get(0).getSortWeight(), is(15.0));
@@ -705,10 +748,10 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 
 		OclConcept set = newOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, set));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, set));
 
 		OclConcept member = newOtherOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, member));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, member));
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
@@ -717,7 +760,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept setConcept = conceptService.getConceptByUuid(set.getExternalId());
 		Concept memberConcept = conceptService.getConceptByUuid(member.getExternalId());
@@ -730,10 +773,10 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 
 		OclConcept set = newOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, set));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, set));
 
 		OclConcept member = newOtherOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, member));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, member));
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
@@ -743,7 +786,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setExtras(newOclMappingExtras(11.0));
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept setConcept = conceptService.getConceptByUuid(set.getExternalId());
 		Concept memberConcept = conceptService.getConceptByUuid(member.getExternalId());
@@ -766,7 +809,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setRetired(true);
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept setConcept = conceptService.getConceptByUuid("6c1bbb30-55f6-11e4-8ed6-0800200c9a66");
 
@@ -794,7 +837,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setExtras(new OclMapping.Extras());
 		oclMapping.getExtras().setSortWeight(5.0);
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		members = membersForConceptSet(setConcept, memberConcept);
 		assertThat(members.size(), is(1));
@@ -807,7 +850,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 
 		OclConcept oclConcept = newOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, oclConcept));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
@@ -817,7 +860,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToSourceName("SNOMED CT");
 		oclMapping.setToConceptCode("1001");
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept concept = conceptService.getConceptByUuid("6c1bbb30-55f6-11e4-8ed6-0800200c9a66");
 
@@ -841,7 +884,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToConceptCode("1001");
 		oclMapping.setRetired(true);
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept concept = conceptService.getConceptByUuid("6c1bbb30-55f6-11e4-8ed6-0800200c9a66");
 		ConceptSource source = conceptService.getConceptSourceByName("SNOMED CT");
@@ -867,7 +910,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToConceptCode("1001");
 		oclMapping.setRetired(false);
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept concept = conceptService.getConceptByUuid("6c1bbb30-55f6-11e4-8ed6-0800200c9a66");
 
@@ -879,7 +922,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void importMapping_shouldUpdateMappingOnylIfItHasBeenUpdatedSinceLastImport() throws Exception {
 		OclConcept oclConcept = newOclConcept();
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), anImport, oclConcept));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept));
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
@@ -890,15 +933,15 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToConceptCode("1001");
 		oclMapping.setUrl("/orgs/CIELTEST/sources/CIELTEST/mappings/303");
 
-		importService.saveItem(saver.saveMapping(new CacheService(conceptService), update, oclMapping));
+		importService.saveItem(saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping));
 		
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
 		
-		Item item = saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		Item item = saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UPDATED)));
 		importService.saveItem(item);
 		
-		item = saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		item = saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UP_TO_DATE)));
 	}
 	
@@ -951,7 +994,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		OclConcept oclConcept = newOclConcept();
 
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, oclConcept));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
@@ -962,7 +1005,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToSourceName("CIELTEST");
 		oclMapping.setToConceptCode("100002");
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept toConcept = conceptService.getConcept(100002);
 		assertEquals(null, toConcept);
@@ -976,7 +1019,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		OclConcept oclConcept = newOclConcept();
 
-		importService.saveItem(saver.saveConcept(new CacheService(conceptService), update, oclConcept));
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
@@ -987,7 +1030,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setToSourceName("CIELTEST");
 		oclMapping.setToConceptCode("100002");
 
-		saver.saveMapping(new CacheService(conceptService), update, oclMapping);
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		Concept fromConcept = conceptService.getConceptByUuid(oclConcept.getExternalId());
 		assertThat(fromConcept.getConceptMappings().size(), is(1));
@@ -1007,13 +1050,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclConcept.setUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclConcept.setVersionUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/54ea96d28a86f20421474a3a/");
 
-		List<Description> descriptons = new ArrayList<OclConcept.Description>();
+		List<Description> descriptions = new ArrayList<OclConcept.Description>();
 		Description description = new Description();
 		description.setExternalId("a54594cf-7612-46c3-90f3-10599f4e3223");
 		description.setDescription("Test description");
 		description.setLocale(Context.getLocale());
-		descriptons.add(description);
-		oclConcept.setDescriptions(descriptons);
+		descriptions.add(description);
+		oclConcept.setDescriptions(descriptions);
 
 		List<Name> names = new ArrayList<OclConcept.Name>();
 		Name name = new Name();

--- a/omod/src/main/java/org/openmrs/module/openconceptlab/web/rest/resources/ImportResource.java
+++ b/omod/src/main/java/org/openmrs/module/openconceptlab/web/rest/resources/ImportResource.java
@@ -165,6 +165,11 @@ public class ImportResource extends DelegatingCrudResource<Import> implements Up
     public static Integer getUpToDateItemsCount(Import instance){
         return getImportService().getImportItemsCount(instance, states(ItemState.UP_TO_DATE));
     }
+    
+    @PropertyGetter("duplicateItems")
+    public static Integer getDuplicateItemCount(Import instance){
+        return getImportService().getImportItemsCount(instance, states(ItemState.DUPLICATE));
+    }
 
     @PropertyGetter("addedItemsCount")
     public static Integer getAddedItemsCount(Import instance){

--- a/owa/app/js/import/import.html
+++ b/owa/app/js/import/import.html
@@ -21,6 +21,7 @@
     <p ng-show="vm.anImport.errorItemsCount > 0"><span class="formatFieldsErrors">{{vm.anImport.errorItemsCount}}</span> errors</p>
     <p ng-show="vm.anImport.ignoredErrorsCount > 0"><span class="formatFields">{{vm.anImport.ignoredErrorsCount}}</span> ignored errors</p>
     <p ng-show="vm.anImport.upToDateItemsCount > 0"><span class="formatFields">{{vm.anImport.upToDateItemsCount}}</span> up to date</p>
+    <p ng-show="vm.anImport.duplicateItems > 0"><span class="formatFields">{{vm.anImport.duplicateItems}}</span> duplicates</p>
     <p ng-show="vm.anImport.addedItemsCount > 0"><span class="formatFields">{{vm.anImport.addedItemsCount}}</span> added</p>
     <p ng-show="vm.anImport.updatedItemsCount > 0"><span class="formatFields">{{vm.anImport.updatedItemsCount}}</span> updated</p>
     <p ng-show="vm.anImport.retiredItemsCount > 0"><span class="formatFields">{{vm.anImport.retiredItemsCount}}</span> retired</p>
@@ -40,6 +41,28 @@
         <tbody>
         <tr ng-repeat="item in vm.items">
             <td class="small" ng-if="item.state === 'ERROR'">{{ item.type }}
+                ({{item.uuid }})<br>
+                <a href="{{item.versionUrl }}">View in OCL</a>
+                {{ item.status}}
+            </td>
+            <td>
+                {{item.errorMessage}}
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<div>
+    <table id="mainDuplicateDetails" ng-if="vm.anImport.duplicateItems > 0">
+        <thead>
+        <tr>
+            <th>Duplicates (listing limited to first 50 duplicate)</th>
+            <th>Message</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr ng-repeat="item in vm.items">
+            <td class="small" ng-if="item.state === 'DUPLICATE'">{{ item.type }}
                 ({{item.uuid }})<br>
                 <a href="{{item.versionUrl }}">View in OCL</a>
                 {{ item.status}}


### PR DESCRIPTION
…e concept exists

This includes one of the key features from #84 but in a slightly different way (instead of using `ConceptService#getConceptByMapping()` this includes a custom implementation that depends on the SAME-AS mapping).