### PR TITLE
OCLOMRS-1123: Add a configurable task to clean-up old import records

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/ItemCleanupService.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ItemCleanupService.java
@@ -1,0 +1,32 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.openconceptlab;
+
+import org.openmrs.annotation.Authorized;
+import org.openmrs.util.PrivilegeConstants;
+
+public interface ItemCleanupService {
+
+	/**
+	 * Executes the cleanup process:
+	 * <ol>
+	 *   <li>Identifies imports eligible for cleanup based on the configured retention policy</li>
+	 *   <li>Preserves at least one non-error Item per unique URL (concept/mapping), if one exists</li>
+	 *   <li>Deletes expired items in batches</li>
+	 *   <li>Deletes orphaned Import records that have no remaining Items</li>
+	 * </ol>
+	 *
+	 * Does nothing if no retention policy is configured.
+	 *
+	 * @return the number of items deleted, or 0 if cleanup is disabled or nothing to clean
+	 */
+	@Authorized(PrivilegeConstants.MANAGE_CONCEPTS)
+	int runCleanup();
+}

--- a/api/src/main/java/org/openmrs/module/openconceptlab/ItemCleanupServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ItemCleanupServiceImpl.java
@@ -1,0 +1,270 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.openconceptlab;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.openmrs.api.AdministrationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ItemCleanupServiceImpl implements ItemCleanupService {
+
+	private static final Logger log = LoggerFactory.getLogger(ItemCleanupServiceImpl.class);
+
+	private static final int DELETE_BATCH_SIZE = 1000;
+
+	private static final String RETENTION_TYPE_RUNS = "RUNS";
+
+	private static final String RETENTION_TYPE_DAYS = "DAYS";
+
+	SessionFactory sessionFactory;
+
+	AdministrationService adminService;
+
+	public void setSessionFactory(SessionFactory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	public void setAdminService(AdministrationService adminService) {
+		this.adminService = adminService;
+	}
+
+	@Override
+	@Transactional
+	public int runCleanup() {
+		String retentionType = adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE);
+		if (StringUtils.isBlank(retentionType)) {
+			log.debug("Item cleanup is disabled (no retention policy configured)");
+			return 0;
+		}
+
+		retentionType = retentionType.trim().toUpperCase();
+		if (!RETENTION_TYPE_RUNS.equals(retentionType) && !RETENTION_TYPE_DAYS.equals(retentionType)) {
+			log.warn("Unknown cleanup retention type: '{}'. Expected RUNS or DAYS.", retentionType);
+			return 0;
+		}
+
+		String retentionValueStr;
+		if (RETENTION_TYPE_RUNS.equals(retentionType)) {
+			retentionValueStr = adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS);
+		} else {
+			retentionValueStr = adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_DAYS);
+		}
+
+		int retentionValue;
+		try {
+			retentionValue = Integer.parseInt(StringUtils.trimToEmpty(retentionValueStr));
+		}
+		catch (NumberFormatException e) {
+			log.warn("Invalid cleanup retention value: '{}'. Skipping cleanup.", retentionValueStr);
+			return 0;
+		}
+
+		if (retentionValue <= 0) {
+			log.warn("Cleanup retention value must be positive, got: {}. Skipping cleanup.", retentionValue);
+			return 0;
+		}
+
+		log.info("Starting item cleanup with policy: {} = {}", retentionType, retentionValue);
+
+		Set<Long> protectedImportIds = getProtectedImportIds(retentionType, retentionValue);
+		Set<Long> preservedItemIds = getLatestItemIdPerUrl();
+
+		int itemsDeleted = deleteEligibleItems(protectedImportIds, preservedItemIds);
+
+		// Ensure item deletions are visible to the orphan detection query
+		getSession().flush();
+		getSession().clear();
+
+		int importsDeleted = deleteOrphanedImports();
+
+		log.info("Cleanup complete: {} items deleted, {} orphaned imports deleted", itemsDeleted, importsDeleted);
+		return itemsDeleted;
+	}
+
+	/**
+	 * Builds the set of import IDs that must not have their items deleted.
+	 * This always includes in-progress imports and the most recent successful import,
+	 * plus imports covered by the retention policy. An import is considered successful
+	 * if it has at least one non-ERROR item (i.e., it actually processed something).
+	 */
+	@SuppressWarnings("unchecked")
+	private Set<Long> getProtectedImportIds(String retentionType, int retentionValue) {
+		Session session = getSession();
+		Set<Long> protectedIds = new HashSet<>();
+
+		// An import is "successful" if it processed at least one item without error.
+		// This distinguishes crashed imports (no items or only ERROR items) from
+		// partially successful ones (some errors but also real work done).
+		String hasNonErrorItems =
+				"EXISTS (SELECT 1 FROM OclItem item WHERE item.anImport = i " +
+				"AND (item.state IS NULL OR item.state <> :errorState))";
+
+		// Always protect in-progress imports
+		List<Long> inProgressIds = session.createQuery(
+				"SELECT i.importId FROM OclImport i WHERE i.localDateStopped IS NULL")
+				.list();
+		protectedIds.addAll(inProgressIds);
+
+		if (RETENTION_TYPE_RUNS.equals(retentionType)) {
+			// Protect the N most recent successful imports.
+			// This implicitly includes the most recent successful import.
+			Query runsQuery = session.createQuery(
+					"SELECT i.importId FROM OclImport i " +
+					"WHERE i.localDateStopped IS NOT NULL " +
+					"AND " + hasNonErrorItems + " " +
+					"ORDER BY i.importId DESC");
+			runsQuery.setParameter("errorState", ItemState.ERROR);
+			runsQuery.setMaxResults(retentionValue);
+			protectedIds.addAll(runsQuery.list());
+		} else {
+			// Protect imports completed within the last N days
+			Calendar cutoff = Calendar.getInstance();
+			cutoff.add(Calendar.DAY_OF_YEAR, -retentionValue);
+			List<Long> dayIds = session.createQuery(
+					"SELECT i.importId FROM OclImport i " +
+					"WHERE i.localDateStopped IS NOT NULL " +
+					"AND i.localDateStopped >= :cutoffDate")
+					.setParameter("cutoffDate", cutoff.getTime())
+					.list();
+			protectedIds.addAll(dayIds);
+
+			// Always protect the most recent successful import even if it's older than the cutoff
+			Query latestQuery = session.createQuery(
+					"SELECT i.importId FROM OclImport i " +
+					"WHERE i.localDateStopped IS NOT NULL " +
+					"AND " + hasNonErrorItems + " " +
+					"ORDER BY i.importId DESC");
+			latestQuery.setParameter("errorState", ItemState.ERROR);
+			latestQuery.setMaxResults(1);
+			Long latestId = (Long) latestQuery.uniqueResult();
+			if (latestId != null) {
+				protectedIds.add(latestId);
+			}
+		}
+
+		return protectedIds;
+	}
+
+	/**
+	 * Returns the item ID of the most recent non-error item for each unique URL.
+	 * These items are preserved regardless of the retention policy to ensure
+	 * at least one successful record exists for every imported concept/mapping
+	 * that has one.
+	 */
+	@SuppressWarnings("unchecked")
+	private Set<Long> getLatestItemIdPerUrl() {
+		// MAX(i.itemId) gives the most recently created item per URL because itemId
+		// is an auto-increment primary key. hashedUrl is indexed for efficient GROUP BY.
+		List<Long> ids = getSession().createQuery(
+				"SELECT MAX(i.itemId) FROM OclItem i " +
+				"WHERE (i.state IS NULL OR i.state <> :errorState) " +
+				"GROUP BY i.hashedUrl")
+				.setParameter("errorState", ItemState.ERROR)
+				.list();
+
+		return new HashSet<>(ids);
+	}
+
+	/**
+	 * Deletes items that are not in protected imports and not the latest item for their URL.
+	 * Uses a two-phase approach (select IDs then delete by ID) to avoid MySQL limitations
+	 * with subqueries on the same table in DELETE statements.
+	 * Fetches eligible IDs in pages using a cursor (itemId ordering) and deletes in batches
+	 * to limit IN-clause parameter list sizes and periodically clear the Hibernate session cache.
+	 */
+	private int deleteEligibleItems(Set<Long> protectedImportIds, Set<Long> preservedItemIds) {
+		if (protectedImportIds.isEmpty()) {
+			// No protected imports means either no imports exist (fresh install) or we
+			// can't safely determine what to keep — either way, nothing to delete
+			log.debug("No protected imports found. Skipping item deletion.");
+			return 0;
+		}
+
+		int totalDeleted = 0;
+		long lastSeenId = 0;
+
+		while (true) {
+			@SuppressWarnings("unchecked")
+			List<Long> batch = getSession().createQuery(
+					"SELECT i.itemId FROM OclItem i " +
+					"WHERE i.anImport.importId NOT IN (:protectedImports) " +
+					"AND i.itemId > :lastSeenId " +
+					"ORDER BY i.itemId")
+					.setParameterList("protectedImports", protectedImportIds)
+					.setParameter("lastSeenId", lastSeenId)
+					.setMaxResults(DELETE_BATCH_SIZE)
+					.list();
+
+			if (batch.isEmpty()) {
+				break;
+			}
+
+			lastSeenId = batch.get(batch.size() - 1);
+
+			// Remove preserved items (latest per URL) in Java to avoid very large NOT IN clauses
+			batch = new ArrayList<>(batch);
+			batch.removeAll(preservedItemIds);
+
+			if (batch.isEmpty()) {
+				continue;
+			}
+
+			int deleted = getSession().createQuery(
+					"DELETE FROM OclItem i WHERE i.itemId IN (:ids)")
+					.setParameterList("ids", batch)
+					.executeUpdate();
+			totalDeleted += deleted;
+
+			getSession().flush();
+			getSession().clear();
+		}
+
+		return totalDeleted;
+	}
+
+	/**
+	 * Deletes completed Import records that have no remaining Items.
+	 * Only deletes imports that are already stopped (never in-progress ones).
+	 */
+	@SuppressWarnings("unchecked")
+	private int deleteOrphanedImports() {
+		List<Long> orphanIds = getSession().createQuery(
+				"SELECT i.importId FROM OclImport i " +
+				"WHERE i.localDateStopped IS NOT NULL " +
+				"AND NOT EXISTS (" +
+				"  SELECT 1 FROM OclItem item WHERE item.anImport = i" +
+				")")
+				.list();
+
+		if (orphanIds.isEmpty()) {
+			return 0;
+		}
+
+		return getSession().createQuery(
+				"DELETE FROM OclImport i WHERE i.importId IN (:ids)")
+				.setParameterList("ids", orphanIds)
+				.executeUpdate();
+	}
+
+	private Session getSession() {
+		return sessionFactory.getCurrentSession();
+	}
+}

--- a/api/src/main/java/org/openmrs/module/openconceptlab/ItemCleanupServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ItemCleanupServiceImpl.java
@@ -191,27 +191,14 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 	 * to limit IN-clause parameter list sizes and periodically clear the Hibernate session cache.
 	 */
 	private int deleteEligibleItems(Set<Long> protectedImportIds, Set<Long> preservedItemIds) {
-		if (protectedImportIds.isEmpty()) {
-			// No protected imports means either no imports exist (fresh install) or we
-			// can't safely determine what to keep — either way, nothing to delete
-			log.debug("No protected imports found. Skipping item deletion.");
-			return 0;
-		}
-
 		int totalDeleted = 0;
 		long lastSeenId = 0;
 
 		while (true) {
-			@SuppressWarnings("unchecked")
-			List<Long> batch = getSession().createQuery(
-					"SELECT i.itemId FROM OclItem i " +
-					"WHERE i.anImport.importId NOT IN (:protectedImports) " +
-					"AND i.itemId > :lastSeenId " +
-					"ORDER BY i.itemId")
-					.setParameterList("protectedImports", protectedImportIds)
-					.setParameter("lastSeenId", lastSeenId)
-					.setMaxResults(DELETE_BATCH_SIZE)
-					.list();
+			// An empty protected set is a legitimate state — e.g. RUNS retention with only
+			// failed imports in history. We still proceed so the accumulated error items
+			// (and their now-orphaned imports) get cleaned up rather than accumulating forever.
+			List<Long> batch = fetchEligibleBatch(protectedImportIds, lastSeenId);
 
 			if (batch.isEmpty()) {
 				break;
@@ -238,6 +225,28 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 		}
 
 		return totalDeleted;
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<Long> fetchEligibleBatch(Set<Long> protectedImportIds, long lastSeenId) {
+		if (protectedImportIds.isEmpty()) {
+			return getSession().createQuery(
+					"SELECT i.itemId FROM OclItem i " +
+					"WHERE i.itemId > :lastSeenId " +
+					"ORDER BY i.itemId")
+					.setParameter("lastSeenId", lastSeenId)
+					.setMaxResults(DELETE_BATCH_SIZE)
+					.list();
+		}
+		return getSession().createQuery(
+				"SELECT i.itemId FROM OclItem i " +
+				"WHERE i.anImport.importId NOT IN (:protectedImports) " +
+				"AND i.itemId > :lastSeenId " +
+				"ORDER BY i.itemId")
+				.setParameterList("protectedImports", protectedImportIds)
+				.setParameter("lastSeenId", lastSeenId)
+				.setMaxResults(DELETE_BATCH_SIZE)
+				.list();
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/openconceptlab/ItemCleanupServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ItemCleanupServiceImpl.java
@@ -10,7 +10,7 @@
 package org.openmrs.module.openconceptlab;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.Query;
+import org.hibernate.query.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.openmrs.api.AdministrationService;
@@ -100,40 +100,57 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 	}
 
 	/**
-	 * Builds the set of import IDs that must not have their items deleted.
-	 * This always includes in-progress imports and the most recent successful import,
-	 * plus imports covered by the retention policy. An import is considered successful
-	 * if it has at least one non-ERROR item (i.e., it actually processed something).
+	 * Builds the set of import IDs whose items must not be deleted. Always includes:
+	 * <ul>
+	 *   <li>in-progress imports (never touched while running)</li>
+	 *   <li>imports covered by the configured retention policy — the N most recent stopped
+	 *       imports under RUNS (regardless of success/failure), or imports stopped within
+	 *       the cutoff under DAYS</li>
+	 *   <li>the most recent successful import (an import with at least one non-ERROR item),
+	 *       pinned so {@code getLastSuccessfulSubscriptionImport()} keeps returning a usable
+	 *       row even if the head of history is all failures</li>
+	 * </ul>
 	 */
-	@SuppressWarnings("unchecked")
 	private Set<Long> getProtectedImportIds(String retentionType, int retentionValue) {
 		Session session = getSession();
-		Set<Long> protectedIds = new HashSet<>();
 
-		// An import is "successful" if it processed at least one item without error.
-		// This distinguishes crashed imports (no items or only ERROR items) from
-		// partially successful ones (some errors but also real work done).
+        // "Successful" = at least one non-ERROR item. This is only used to pin the most
+		// recent good import; retention itself counts every stopped import regardless of
+		// state. Without the pin, a string of failures could push every successful import
+		// out of the retain window, forcing a full refetch on the next incremental update.
 		String hasNonErrorItems =
 				"EXISTS (SELECT 1 FROM OclItem item WHERE item.anImport = i " +
 				"AND (item.state IS NULL OR item.state <> :errorState))";
 
 		// Always protect in-progress imports
 		List<Long> inProgressIds = session.createQuery(
-				"SELECT i.importId FROM OclImport i WHERE i.localDateStopped IS NULL")
+				"SELECT i.importId FROM OclImport i WHERE i.localDateStopped IS NULL", Long.class)
 				.list();
-		protectedIds.addAll(inProgressIds);
+        Set<Long> protectedIds = new HashSet<>(inProgressIds);
 
 		if (RETENTION_TYPE_RUNS.equals(retentionType)) {
-			// Protect the N most recent successful imports.
-			// This implicitly includes the most recent successful import.
-			Query runsQuery = session.createQuery(
+			// Protect the N most recent stopped imports regardless of state
+			List<Long> recentIds = session.createQuery(
+					"SELECT i.importId FROM OclImport i " +
+					"WHERE i.localDateStopped IS NOT NULL " +
+					"ORDER BY i.importId DESC", Long.class)
+					.setMaxResults(retentionValue)
+					.list();
+			protectedIds.addAll(recentIds);
+
+			// Additionally, pin the most recent successful import (may be older than the
+			// retention window) so incremental updates can still resume from it.
+			Query<Long> latestSuccessful = session.createQuery(
 					"SELECT i.importId FROM OclImport i " +
 					"WHERE i.localDateStopped IS NOT NULL " +
 					"AND " + hasNonErrorItems + " " +
-					"ORDER BY i.importId DESC");
-			runsQuery.setParameter("errorState", ItemState.ERROR);
-			runsQuery.setMaxResults(retentionValue);
-			protectedIds.addAll(runsQuery.list());
+					"ORDER BY i.importId DESC", Long.class);
+			latestSuccessful.setParameter("errorState", ItemState.ERROR);
+			latestSuccessful.setMaxResults(1);
+			Long latestSuccessfulId = latestSuccessful.uniqueResult();
+			if (latestSuccessfulId != null) {
+				protectedIds.add(latestSuccessfulId);
+			}
 		} else {
 			// Protect imports completed within the last N days
 			Calendar cutoff = Calendar.getInstance();
@@ -141,20 +158,20 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 			List<Long> dayIds = session.createQuery(
 					"SELECT i.importId FROM OclImport i " +
 					"WHERE i.localDateStopped IS NOT NULL " +
-					"AND i.localDateStopped >= :cutoffDate")
+					"AND i.localDateStopped >= :cutoffDate", Long.class)
 					.setParameter("cutoffDate", cutoff.getTime())
 					.list();
 			protectedIds.addAll(dayIds);
 
 			// Always protect the most recent successful import even if it's older than the cutoff
-			Query latestQuery = session.createQuery(
+			Query<Long> latestQuery = session.createQuery(
 					"SELECT i.importId FROM OclImport i " +
 					"WHERE i.localDateStopped IS NOT NULL " +
 					"AND " + hasNonErrorItems + " " +
-					"ORDER BY i.importId DESC");
+					"ORDER BY i.importId DESC", Long.class);
 			latestQuery.setParameter("errorState", ItemState.ERROR);
 			latestQuery.setMaxResults(1);
-			Long latestId = (Long) latestQuery.uniqueResult();
+			Long latestId = latestQuery.uniqueResult();
 			if (latestId != null) {
 				protectedIds.add(latestId);
 			}
@@ -169,14 +186,13 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 	 * at least one successful record exists for every imported concept/mapping
 	 * that has one.
 	 */
-	@SuppressWarnings("unchecked")
 	private Set<Long> getLatestItemIdPerUrl() {
 		// MAX(i.itemId) gives the most recently created item per URL because itemId
 		// is an auto-increment primary key. hashedUrl is indexed for efficient GROUP BY.
 		List<Long> ids = getSession().createQuery(
 				"SELECT MAX(i.itemId) FROM OclItem i " +
 				"WHERE (i.state IS NULL OR i.state <> :errorState) " +
-				"GROUP BY i.hashedUrl")
+				"GROUP BY i.hashedUrl", Long.class)
 				.setParameter("errorState", ItemState.ERROR)
 				.list();
 
@@ -195,9 +211,10 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 		long lastSeenId = 0;
 
 		while (true) {
-			// An empty protected set is a legitimate state — e.g. RUNS retention with only
-			// failed imports in history. We still proceed so the accumulated error items
-			// (and their now-orphaned imports) get cleaned up rather than accumulating forever.
+			// An empty protected set is a legitimate state — e.g. a fresh install with no
+			// imports, or DAYS retention where every import is older than the cutoff and
+			// no successful import exists to pin. We still proceed so orphaned items get
+			// cleaned up rather than accumulating forever.
 			List<Long> batch = fetchEligibleBatch(protectedImportIds, lastSeenId);
 
 			if (batch.isEmpty()) {
@@ -227,13 +244,12 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 		return totalDeleted;
 	}
 
-	@SuppressWarnings("unchecked")
 	private List<Long> fetchEligibleBatch(Set<Long> protectedImportIds, long lastSeenId) {
 		if (protectedImportIds.isEmpty()) {
 			return getSession().createQuery(
 					"SELECT i.itemId FROM OclItem i " +
 					"WHERE i.itemId > :lastSeenId " +
-					"ORDER BY i.itemId")
+					"ORDER BY i.itemId", Long.class)
 					.setParameter("lastSeenId", lastSeenId)
 					.setMaxResults(DELETE_BATCH_SIZE)
 					.list();
@@ -242,7 +258,7 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 				"SELECT i.itemId FROM OclItem i " +
 				"WHERE i.anImport.importId NOT IN (:protectedImports) " +
 				"AND i.itemId > :lastSeenId " +
-				"ORDER BY i.itemId")
+				"ORDER BY i.itemId", Long.class)
 				.setParameterList("protectedImports", protectedImportIds)
 				.setParameter("lastSeenId", lastSeenId)
 				.setMaxResults(DELETE_BATCH_SIZE)
@@ -253,14 +269,13 @@ public class ItemCleanupServiceImpl implements ItemCleanupService {
 	 * Deletes completed Import records that have no remaining Items.
 	 * Only deletes imports that are already stopped (never in-progress ones).
 	 */
-	@SuppressWarnings("unchecked")
 	private int deleteOrphanedImports() {
 		List<Long> orphanIds = getSession().createQuery(
 				"SELECT i.importId FROM OclImport i " +
 				"WHERE i.localDateStopped IS NOT NULL " +
 				"AND NOT EXISTS (" +
 				"  SELECT 1 FROM OclItem item WHERE item.anImport = i" +
-				")")
+				")", Long.class)
 				.list();
 
 		if (orphanIds.isEmpty()) {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabConstants.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabConstants.java
@@ -37,5 +37,10 @@ public class OpenConceptLabConstants {
 	public static final String GP_VALIDATION_TYPE = MODULE_ID + ".validationType";
 	public static final String GP_OCL_LOAD_AT_STARTUP_PATH = MODULE_ID + ".oclLoadAtStartupPath";
 
+	public static final String GP_CLEANUP_RETENTION_TYPE = MODULE_ID + ".cleanupRetentionType";
+	public static final String GP_CLEANUP_RETAIN_IMPORTS = MODULE_ID + ".cleanupRetainImports";
+	public static final String GP_CLEANUP_RETAIN_DAYS = MODULE_ID + ".cleanupRetainDays";
+	public static final String GP_CLEANUP_DELAY_MINUTES = MODULE_ID + ".cleanupDelayMinutes";
+
 	public static final UUID OPEN_CONCEPT_LAB_NAMESPACE_UUID = UUID.fromString("672c6cb2-4f47-4cb0-9fca-b5f6116cd33a");
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Importer.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Importer.java
@@ -34,6 +34,7 @@ import org.openmrs.module.openconceptlab.client.OclClient;
 import org.openmrs.module.openconceptlab.client.OclClient.OclResponse;
 import org.openmrs.module.openconceptlab.client.OclConcept;
 import org.openmrs.module.openconceptlab.client.OclMapping;
+import org.openmrs.module.openconceptlab.scheduler.CleanupScheduler;
 import org.openmrs.module.openconceptlab.scheduler.UpdateScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +67,8 @@ public class Importer implements Runnable {
 
 	private Saver saver;
 
+	private CleanupScheduler cleanupScheduler;
+
 	private volatile Import anImport;
 
 	private CountingInputStream in = null;
@@ -96,6 +99,10 @@ public class Importer implements Runnable {
 
     public void setSaver(Saver persister) {
 	    this.saver = persister;
+    }
+
+    public void setCleanupScheduler(CleanupScheduler cleanupScheduler) {
+	    this.cleanupScheduler = cleanupScheduler;
     }
 
 	public void setZipFile(ZipFile zipFile) {
@@ -226,6 +233,15 @@ public class Importer implements Runnable {
 			}
 			catch (Exception e) {
 				log.error("Failed to stop anImport", e);
+			}
+
+			try {
+				if (cleanupScheduler != null) {
+					cleanupScheduler.scheduleCleanup();
+				}
+			}
+			catch (Exception e) {
+				log.error("Failed to schedule cleanup", e);
 			}
 
 			in = null;

--- a/api/src/main/java/org/openmrs/module/openconceptlab/scheduler/CleanupScheduler.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/scheduler/CleanupScheduler.java
@@ -1,0 +1,121 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.openconceptlab.scheduler;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.api.context.Daemon;
+import org.openmrs.module.DaemonToken;
+import org.openmrs.module.openconceptlab.ItemCleanupService;
+import org.openmrs.module.openconceptlab.OpenConceptLabActivator;
+import org.openmrs.module.openconceptlab.OpenConceptLabConstants;
+import org.openmrs.api.AdministrationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.Date;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Manages debounced scheduling of item cleanup after imports complete.
+ * Each call to {@link #scheduleCleanup()} cancels any previously scheduled cleanup
+ * and reschedules it after the configured delay, ensuring that rapid successive
+ * imports (e.g., during startup) only trigger a single cleanup run.
+ */
+public class CleanupScheduler {
+
+	private static final Logger log = LoggerFactory.getLogger(CleanupScheduler.class);
+
+	private static final int DEFAULT_DELAY_MINUTES = 5;
+
+	private static final int MAX_RETRIES = 1;
+
+	ThreadPoolTaskScheduler scheduler;
+
+	ItemCleanupService cleanupService;
+
+	AdministrationService adminService;
+
+	private volatile ScheduledFuture<?> scheduledCleanup;
+
+	private final AtomicInteger retryCount = new AtomicInteger(0);
+
+	public void setScheduler(ThreadPoolTaskScheduler scheduler) {
+		this.scheduler = scheduler;
+	}
+
+	public void setCleanupService(ItemCleanupService cleanupService) {
+		this.cleanupService = cleanupService;
+	}
+
+	public void setAdminService(AdministrationService adminService) {
+		this.adminService = adminService;
+	}
+
+	/**
+	 * Schedules cleanup to run after the configured delay.
+	 * If a cleanup is already pending, it is cancelled and rescheduled (debounce).
+	 */
+	public synchronized void scheduleCleanup() {
+		if (scheduledCleanup != null && !scheduledCleanup.isDone()) {
+			log.debug("Cancelling previously scheduled cleanup (debounce)");
+			scheduledCleanup.cancel(false);
+		}
+
+		int delayMinutes = getCleanupDelayMinutes();
+		Date runAt = new Date(System.currentTimeMillis() + (delayMinutes * 60 * 1000L));
+		log.info("Scheduling item cleanup to run at {}", runAt);
+
+		scheduledCleanup = scheduler.schedule(this::runCleanup, runAt);
+	}
+
+	private void runCleanup() {
+		DaemonToken token = OpenConceptLabActivator.getDaemonToken();
+		if (token == null) {
+			log.warn("Daemon token not available, skipping item cleanup. Module may have been stopped.");
+			return;
+		}
+
+		Daemon.runInDaemonThreadAndWait(() -> {
+			try {
+				cleanupService.runCleanup();
+				retryCount.set(0);
+			}
+			catch (Exception e) {
+				log.error("Error during item cleanup", e);
+				if (retryCount.incrementAndGet() <= MAX_RETRIES) {
+					log.info("Scheduling cleanup retry (attempt {})", retryCount.get());
+					scheduleCleanup();
+				} else {
+					log.error("Item cleanup failed after {} retries. Will retry after the next import.", MAX_RETRIES);
+					retryCount.set(0);
+				}
+			}
+		}, token);
+	}
+
+	private int getCleanupDelayMinutes() {
+		String value = adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_DELAY_MINUTES);
+		if (StringUtils.isNotBlank(value)) {
+			try {
+				int minutes = Integer.parseInt(value.trim());
+				if (minutes > 0) {
+					return minutes;
+				}
+				log.warn("Cleanup delay minutes must be positive, got: '{}'. Using default: {}", value, DEFAULT_DELAY_MINUTES);
+			}
+			catch (NumberFormatException e) {
+				log.warn("Invalid cleanup delay minutes: '{}'. Using default: {}", value, DEFAULT_DELAY_MINUTES);
+			}
+		}
+		return DEFAULT_DELAY_MINUTES;
+	}
+}

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -56,6 +56,36 @@
 		</property>
 	</bean>
 
+	<task:scheduler id="openconceptlab.cleanupScheduler.taskScheduler" pool-size="1"/>
+
+	<bean id="openconceptlab.cleanupService"
+		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager" ref="transactionManager"/>
+		<property name="target">
+			<bean class="org.openmrs.module.openconceptlab.ItemCleanupServiceImpl">
+				<property name="sessionFactory" ref="sessionFactory" />
+				<property name="adminService" ref="adminService" />
+			</bean>
+		</property>
+		<property name="preInterceptors" ref="serviceInterceptors"/>
+		<property name="transactionAttributeSource" ref="transactionAttributeSource"/>
+	</bean>
+
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list>
+				<value>org.openmrs.module.openconceptlab.ItemCleanupService</value>
+				<ref bean="openconceptlab.cleanupService"/>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="openconceptlab.cleanupScheduler" class="org.openmrs.module.openconceptlab.scheduler.CleanupScheduler">
+		<property name="scheduler" ref="openconceptlab.cleanupScheduler.taskScheduler"/>
+		<property name="cleanupService" ref="openconceptlab.cleanupService" />
+		<property name="adminService" ref="adminService" />
+	</bean>
+
 	<bean id="openconceptlab.oclClient" class="org.openmrs.module.openconceptlab.client.OclClient" />
 	
 	<bean id="openconceptlab.saver" class="org.openmrs.module.openconceptlab.importer.Saver">
@@ -69,6 +99,7 @@
 		<property name="oclConceptService" ref="openconceptlab.conceptService" />
 		<property name="oclClient" ref="openconceptlab.oclClient" />
 		<property name="saver" ref="openconceptlab.saver" />
+		<property name="cleanupScheduler" ref="openconceptlab.cleanupScheduler" />
 	</bean>
 	
 	<bean id="openconceptlab.updateScheduler" class="org.openmrs.module.openconceptlab.scheduler.UpdateScheduler">

--- a/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
@@ -25,6 +25,8 @@ import org.openmrs.ConceptName;
 import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.context.Daemon;
+import org.openmrs.module.DaemonToken;
 import org.openmrs.module.openconceptlab.client.OclClient;
 import org.openmrs.module.openconceptlab.importer.Importer;
 import org.openmrs.module.openconceptlab.importer.Saver;
@@ -45,13 +47,13 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.zip.ZipFile;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.openmrs.module.openconceptlab.client.OclClient.FILE_NAME_FORMAT;
 
@@ -149,7 +151,6 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 
 	/**
      * @see ImportServiceImpl#stopImport(Import)
-     * @verifies throw IllegalStateException if trying to stop twice
      */
     @Test
     public void stopUpdate_shouldThrowIllegalStateExceptionIfTryingToStopTwice() throws Exception {
@@ -626,6 +627,17 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 					lastImport.getSubscriptionUrl());
 		} finally {
 			RootLogger.getRootLogger().setLevel(rootLoggerLevel);
+			// importer.run(zipFile) hands work to a daemon thread whose transaction commits
+			// independently of the test's rolled-back transaction, leaving Items/Imports in
+			// the shared H2 instance and polluting later test classes. Run the wipe in
+			// another daemon thread so its DELETEs commit on the same out-of-test path.
+			DaemonToken token = OpenConceptLabActivator.getDaemonToken();
+			if (token != null) {
+				Daemon.runInDaemonThreadAndWait(() -> {
+					Context.getAdministrationService().executeSQL("DELETE FROM openconceptlab_item", false);
+					Context.getAdministrationService().executeSQL("DELETE FROM openconceptlab_import", false);
+				}, token);
+			}
 		}
 	}
 }

--- a/api/src/test/java/org/openmrs/module/openconceptlab/ItemCleanupServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/ItemCleanupServiceTest.java
@@ -1,0 +1,435 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.openconceptlab;
+
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.GlobalProperty;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.openconceptlab.client.OclConcept;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ItemCleanupServiceTest extends BaseModuleContextSensitiveTest {
+
+	@Autowired @Qualifier("openconceptlab.importService")
+	private ImportService importService;
+
+	@Autowired @Qualifier("openconceptlab.cleanupService")
+	private ItemCleanupService cleanupService;
+
+	@Autowired
+	private SessionFactory sessionFactory;
+
+	private AdministrationService adminService;
+
+	@Before
+	public void setUp() {
+		adminService = Context.getAdministrationService();
+	}
+
+	@Test
+	public void runCleanup_shouldDoNothingWhenNoRetentionPolicyConfigured() {
+		// No retention type set - cleanup should be a no-op
+		int deleted = cleanupService.runCleanup();
+		assertThat(deleted, is(0));
+	}
+
+	@Test
+	public void runCleanup_shouldDoNothingForInvalidRetentionType() {
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "INVALID");
+		int deleted = cleanupService.runCleanup();
+		assertThat(deleted, is(0));
+	}
+
+	@Test
+	public void runCleanup_shouldDeleteItemsOlderThanRetainedImports() {
+		// Create 4 completed imports, each with one item for a unique URL
+		Import import1 = createAndStopImport();
+		Item item1a = createItem(import1, "/orgs/test/concepts/1/", "uuid-1a");
+		importService.saveItem(item1a);
+
+		Import import2 = createAndStopImport();
+		Item item2a = createItem(import2, "/orgs/test/concepts/2/", "uuid-2a");
+		importService.saveItem(item2a);
+
+		Import import3 = createAndStopImport();
+		Item item3a = createItem(import3, "/orgs/test/concepts/3/", "uuid-3a");
+		importService.saveItem(item3a);
+
+		Import import4 = createAndStopImport();
+		Item item4a = createItem(import4, "/orgs/test/concepts/4/", "uuid-4a");
+		importService.saveItem(item4a);
+
+		// Configure to keep only the 2 most recent imports
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "2");
+
+		cleanupService.runCleanup();
+
+		// Items from import1 and import2 are outside the retention window,
+		// but each URL only has one item so they must all be preserved.
+		assertThat(importService.getImportItems(import1, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import2, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import3, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import4, 0, 100, new HashSet<>()).size(), is(1));
+	}
+
+	@Test
+	public void runCleanup_shouldDeleteOlderDuplicateItemsButPreserveLatestPerUrl() {
+		// Create 4 imports, all touching the same concept URL
+		Import import1 = createAndStopImport();
+		Item item1 = createItem(import1, "/orgs/test/concepts/1/", "uuid-1");
+		importService.saveItem(item1);
+
+		Import import2 = createAndStopImport();
+		Item item2 = createItem(import2, "/orgs/test/concepts/1/", "uuid-1");
+		importService.saveItem(item2);
+
+		Import import3 = createAndStopImport();
+		Item item3 = createItem(import3, "/orgs/test/concepts/1/", "uuid-1");
+		importService.saveItem(item3);
+
+		Import import4 = createAndStopImport();
+		Item item4 = createItem(import4, "/orgs/test/concepts/1/", "uuid-1");
+		importService.saveItem(item4);
+
+		// Keep 2 most recent imports (import3, import4)
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "2");
+
+		int deleted = cleanupService.runCleanup();
+
+		// import1 and import2 items are outside retention, and item4 is the latest per URL.
+		// So items from import1 and import2 should be deleted.
+		assertThat(deleted, greaterThanOrEqualTo(2));
+
+		assertThat(importService.getImportItems(import1, 0, 100, new HashSet<>()).size(), is(0));
+		assertThat(importService.getImportItems(import2, 0, 100, new HashSet<>()).size(), is(0));
+		assertThat(importService.getImportItems(import3, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import4, 0, 100, new HashSet<>()).size(), is(1));
+	}
+
+	@Test
+	public void runCleanup_shouldPreserveLatestItemPerUrlEvenIfExpired() {
+		// A concept that only appeared in old imports should still keep one item
+		Import import1 = createAndStopImport();
+		Item item1 = createItem(import1, "/orgs/test/concepts/old/", "uuid-old");
+		importService.saveItem(item1);
+
+		// Create 2 more recent imports that don't touch this concept
+		Import import2 = createAndStopImport();
+		Item item2 = createItem(import2, "/orgs/test/concepts/new/", "uuid-new");
+		importService.saveItem(item2);
+
+		Import import3 = createAndStopImport();
+		Item item3 = createItem(import3, "/orgs/test/concepts/new/", "uuid-new");
+		importService.saveItem(item3);
+
+		// Keep only 2 most recent imports (import2, import3)
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "2");
+
+		cleanupService.runCleanup();
+
+		// item1 is in an old import BUT is the only item for its URL, so it must be preserved
+		assertThat(importService.getImportItems(import1, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import2, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import3, 0, 100, new HashSet<>()).size(), is(1));
+	}
+
+	@Test
+	public void runCleanup_shouldNotDeleteItemsFromInProgressImports() {
+		// Create 2 completed imports and 1 in-progress, all touching the same URL
+		Import import1 = createAndStopImport();
+		importService.saveItem(createItem(import1, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import import2 = createAndStopImport();
+		importService.saveItem(createItem(import2, "/orgs/test/concepts/1/", "uuid-1"));
+
+		// In-progress import (not stopped)
+		Import inProgress = new Import();
+		importService.startImport(inProgress);
+		importService.saveItem(createItem(inProgress, "/orgs/test/concepts/1/", "uuid-1"));
+
+		// Keep only 1 completed import (import2). import1 is outside retention.
+		// In-progress import is always protected.
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "1");
+
+		int deleted = cleanupService.runCleanup();
+
+		// import1 is outside retention, its item is not the latest per URL (that's in inProgress),
+		// so it should be deleted.
+		assertThat(deleted, greaterThanOrEqualTo(1));
+
+		assertThat(importService.getImportItems(import1, 0, 100, new HashSet<>()).size(), is(0));
+		assertThat(importService.getImportItems(import2, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(inProgress, 0, 100, new HashSet<>()).size(), is(1));
+
+		// Stop the in-progress import for cleanup
+		importService.stopImport(inProgress);
+	}
+
+	@Test
+	public void runCleanup_shouldNotDeleteItemsFromMostRecentCompletedImport() {
+		// Even with RUNS=1, the most recent completed import is always protected
+		Import import1 = createAndStopImport();
+		Item item1 = createItem(import1, "/orgs/test/concepts/1/", "uuid-1");
+		importService.saveItem(item1);
+
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "1");
+
+		cleanupService.runCleanup();
+
+		// import1 is the most recent completed import, so it's protected
+		assertThat(importService.getImportItems(import1, 0, 100, new HashSet<>()).size(), is(1));
+	}
+
+	@Test
+	public void runCleanup_shouldDeleteOrphanedImports() {
+		// Create 4 imports, all with the same concept
+		Import import1 = createAndStopImport();
+		importService.saveItem(createItem(import1, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import import2 = createAndStopImport();
+		importService.saveItem(createItem(import2, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import import3 = createAndStopImport();
+		importService.saveItem(createItem(import3, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import import4 = createAndStopImport();
+		importService.saveItem(createItem(import4, "/orgs/test/concepts/1/", "uuid-1"));
+
+		// Keep only 2 most recent imports
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "2");
+
+		cleanupService.runCleanup();
+
+		// import1 and import2 should have had their items deleted and then been
+		// deleted themselves as orphans.
+		List<Import> remaining = importService.getImportsInOrder(0, 1000);
+		Set<Long> remainingIds = new HashSet<>();
+		for (Import i : remaining) {
+			remainingIds.add(i.getImportId());
+		}
+		assertThat(remainingIds.contains(import1.getImportId()), is(false));
+		assertThat(remainingIds.contains(import2.getImportId()), is(false));
+		assertThat(remainingIds.contains(import3.getImportId()), is(true));
+		assertThat(remainingIds.contains(import4.getImportId()), is(true));
+	}
+
+	@Test
+	public void runCleanup_shouldWorkWithDaysRetentionPolicy() {
+		// Create an old import (items are old but import is already stopped)
+		Import oldImport = createAndStopImport();
+		Item oldItem = createItem(oldImport, "/orgs/test/concepts/1/", "uuid-1");
+		importService.saveItem(oldItem);
+
+		// Create a recent import with the same concept
+		Import recentImport = createAndStopImport();
+		Item recentItem = createItem(recentImport, "/orgs/test/concepts/1/", "uuid-1");
+		importService.saveItem(recentItem);
+
+		// With DAYS retention, both imports were "just now" so both are within retention
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "DAYS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_DAYS, "1");
+
+		cleanupService.runCleanup();
+
+		// Both imports are within the 1-day window, so nothing should be deleted
+		assertThat(importService.getImportItems(oldImport, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(recentImport, 0, 100, new HashSet<>()).size(), is(1));
+	}
+
+	@Test
+	public void runCleanup_shouldNotCountFailedImportsAsRecentForRunsRetention() {
+		// Create 3 successful imports and 1 failed import (most recent), all touching the same URL
+		Import import1 = createAndStopImport();
+		importService.saveItem(createItem(import1, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import import2 = createAndStopImport();
+		importService.saveItem(createItem(import2, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import import3 = createAndStopImport();
+		importService.saveItem(createItem(import3, "/orgs/test/concepts/1/", "uuid-1"));
+
+		// Failed import is the most recent completed import (only has ERROR items)
+		Import failedImport = createAndFailImport("Something went wrong");
+		importService.saveItem(createErrorItem(failedImport, "/orgs/test/concepts/1/", "uuid-1"));
+
+		// Keep only 2 most recent successful imports (import2, import3).
+		// The failed import should NOT count toward the 2.
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "2");
+
+		int deleted = cleanupService.runCleanup();
+
+		// import1 is outside retention (it's the 3rd successful import back).
+		// failedImport is not protected by the RUNS count.
+		// The latest *successful* item per URL is in import3 (protected), so:
+		// - import1's ADDED item is eligible and deleted
+		// - failedImport's ERROR item is eligible and deleted (ERROR items aren't preserved per URL)
+		assertThat(deleted, greaterThanOrEqualTo(2));
+
+		assertThat(importService.getImportItems(import1, 0, 100, new HashSet<>()).size(), is(0));
+		assertThat(importService.getImportItems(import2, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import3, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(failedImport, 0, 100, new HashSet<>()).size(), is(0));
+	}
+
+	@Test
+	public void runCleanup_shouldDeleteItemsFromImportsOlderThanRetainedDays() {
+		// Create an old import with two concepts
+		Import oldImport = createAndStopImport();
+		importService.saveItem(createItem(oldImport, "/orgs/test/concepts/1/", "uuid-1"));
+		importService.saveItem(createItem(oldImport, "/orgs/test/concepts/2/", "uuid-2"));
+		backdateImport(oldImport, 60);
+
+		// Create a recent import that touches concept 1 (so old import's concept-1 item is not the latest per URL)
+		Import recentImport = createAndStopImport();
+		importService.saveItem(createItem(recentImport, "/orgs/test/concepts/1/", "uuid-1"));
+
+		// Retain imports from the last 7 days — oldImport is 60 days old, so it's outside the window
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "DAYS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_DAYS, "7");
+
+		int deleted = cleanupService.runCleanup();
+
+		// oldImport's concept-1 item should be deleted (recentImport has a newer one for that URL).
+		// oldImport's concept-2 item is the only item for its URL, so it must be preserved.
+		assertThat(deleted, greaterThanOrEqualTo(1));
+		assertThat(importService.getImportItems(oldImport, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(recentImport, 0, 100, new HashSet<>()).size(), is(1));
+	}
+
+	@Test
+	public void runCleanup_shouldProtectLatestSuccessfulImportForDaysRetention() {
+		// Create 1 successful import and then a failed import (most recent)
+		Import successfulImport = createAndStopImport();
+		importService.saveItem(createItem(successfulImport, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import failedImport = createAndFailImport("Connection timeout");
+		importService.saveItem(createErrorItem(failedImport, "/orgs/test/concepts/1/", "uuid-1"));
+
+		// Both imports were just created, so both are within the 1-day window.
+		// The "always protect the most recent successful import" guarantee should apply
+		// to successfulImport, not failedImport.
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "DAYS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_DAYS, "1");
+
+		cleanupService.runCleanup();
+
+		// Both imports are within the 1-day window, so both are protected by the date range.
+		assertThat(importService.getImportItems(successfulImport, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(failedImport, 0, 100, new HashSet<>()).size(), is(1));
+	}
+
+	@Test
+	public void runCleanup_shouldHandleMultipleUrlsAcrossImports() {
+		// Import1: concepts A, B
+		Import import1 = createAndStopImport();
+		importService.saveItem(createItem(import1, "/orgs/test/concepts/A/", "uuid-A"));
+		importService.saveItem(createItem(import1, "/orgs/test/concepts/B/", "uuid-B"));
+
+		// Import2: concepts A, C
+		Import import2 = createAndStopImport();
+		importService.saveItem(createItem(import2, "/orgs/test/concepts/A/", "uuid-A"));
+		importService.saveItem(createItem(import2, "/orgs/test/concepts/C/", "uuid-C"));
+
+		// Import3: concept A
+		Import import3 = createAndStopImport();
+		importService.saveItem(createItem(import3, "/orgs/test/concepts/A/", "uuid-A"));
+
+		// Keep only 1 most recent import (import3)
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "1");
+
+		int deleted = cleanupService.runCleanup();
+
+		// import1 and import2 are outside retention.
+		// Concept A's latest item is in import3 (protected), so items from import1 and import2 for A can be deleted.
+		// Concept B's only item is in import1 - must be preserved (latest per URL).
+		// Concept C's only item is in import2 - must be preserved (latest per URL).
+		assertThat(deleted, greaterThanOrEqualTo(2));
+
+		// import1 had A and B; A is deleted, B is preserved as the only item for its URL
+		assertThat(importService.getImportItems(import1, 0, 100, new HashSet<>()).size(), is(1));
+		// import2 had A and C; A is deleted, C is preserved as the only item for its URL
+		assertThat(importService.getImportItems(import2, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import3, 0, 100, new HashSet<>()).size(), is(1));
+	}
+
+	private Import createAndStopImport() {
+		Import anImport = new Import();
+		importService.startImport(anImport);
+		importService.stopImport(anImport);
+		return anImport;
+	}
+
+	private Import createAndFailImport(String errorMessage) {
+		Import anImport = new Import();
+		importService.startImport(anImport);
+		importService.failImport(anImport, errorMessage);
+		importService.stopImport(anImport);
+		return anImport;
+	}
+
+	private Item createErrorItem(Import anImport, String url, String uuid) {
+		OclConcept concept = new OclConcept();
+		concept.setUrl(url);
+		concept.setVersionUrl(url + "v1/");
+		concept.setExternalId(uuid);
+		return new Item(anImport, concept, ItemState.ERROR);
+	}
+
+	private Item createItem(Import anImport, String url, String uuid) {
+		OclConcept concept = new OclConcept();
+		concept.setUrl(url);
+		concept.setVersionUrl(url + "v1/");
+		concept.setExternalId(uuid);
+		return new Item(anImport, concept, ItemState.ADDED);
+	}
+
+	private void backdateImport(Import anImport, int daysAgo) {
+		Calendar cal = Calendar.getInstance();
+		cal.add(Calendar.DAY_OF_YEAR, -daysAgo);
+		sessionFactory.getCurrentSession().createQuery(
+				"UPDATE OclImport SET localDateStopped = :date WHERE importId = :id")
+				.setParameter("date", cal.getTime())
+				.setParameter("id", anImport.getImportId())
+				.executeUpdate();
+		sessionFactory.getCurrentSession().flush();
+		sessionFactory.getCurrentSession().clear();
+	}
+
+	private void setGlobalProperty(String key, String value) {
+		GlobalProperty gp = adminService.getGlobalPropertyObject(key);
+		if (gp == null) {
+			gp = new GlobalProperty(key);
+		}
+		gp.setPropertyValue(value);
+		adminService.saveGlobalProperty(gp);
+	}
+}

--- a/api/src/test/java/org/openmrs/module/openconceptlab/ItemCleanupServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/ItemCleanupServiceTest.java
@@ -25,9 +25,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class ItemCleanupServiceTest extends BaseModuleContextSensitiveTest {
 
@@ -264,8 +264,10 @@ public class ItemCleanupServiceTest extends BaseModuleContextSensitiveTest {
 	}
 
 	@Test
-	public void runCleanup_shouldNotCountFailedImportsAsRecentForRunsRetention() {
-		// Create 3 successful imports and 1 failed import (most recent), all touching the same URL
+	public void runCleanup_shouldCountFailedImportsTowardRunsBudget() {
+		// Under RUNS retention, every stopped import counts toward the N most recent
+		// budget — a failed import does not "skip the queue", it consumes a slot the
+		// same as any other run. Admins reason about RUNS as "keep the N most recent".
 		Import import1 = createAndStopImport();
 		importService.saveItem(createItem(import1, "/orgs/test/concepts/1/", "uuid-1"));
 
@@ -275,36 +277,32 @@ public class ItemCleanupServiceTest extends BaseModuleContextSensitiveTest {
 		Import import3 = createAndStopImport();
 		importService.saveItem(createItem(import3, "/orgs/test/concepts/1/", "uuid-1"));
 
-		// Failed import is the most recent completed import (only has ERROR items)
 		Import failedImport = createAndFailImport("Something went wrong");
 		importService.saveItem(createErrorItem(failedImport, "/orgs/test/concepts/1/", "uuid-1"));
 
-		// Keep only 2 most recent successful imports (import2, import3).
-		// The failed import should NOT count toward the 2.
+		// RUNS=2 protects import3 and failedImport (the two most recent). import3 is
+		// also the latest successful import, so the pin is redundant here.
 		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
 		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "2");
 
 		int deleted = cleanupService.runCleanup();
 
-		// import1 is outside retention (it's the 3rd successful import back).
-		// failedImport is not protected by the RUNS count.
-		// The latest *successful* item per URL is in import3 (protected), so:
-		// - import1's ADDED item is eligible and deleted
-		// - failedImport's ERROR item is eligible and deleted (ERROR items aren't preserved per URL)
-		assertThat(deleted, greaterThanOrEqualTo(2));
+		// import1 and import2 are outside the window. Their items aren't the latest
+		// non-error item per URL (import3 holds that), so both get deleted.
+		assertThat(deleted, is(2));
 
 		assertThat(importService.getImportItems(import1, 0, 100, new HashSet<>()).size(), is(0));
-		assertThat(importService.getImportItems(import2, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(import2, 0, 100, new HashSet<>()).size(), is(0));
 		assertThat(importService.getImportItems(import3, 0, 100, new HashSet<>()).size(), is(1));
-		assertThat(importService.getImportItems(failedImport, 0, 100, new HashSet<>()).size(), is(0));
+		// failedImport is within the retain window — its ERROR item survives.
+		assertThat(importService.getImportItems(failedImport, 0, 100, new HashSet<>()).size(), is(1));
 	}
 
 	@Test
-	public void runCleanup_shouldCleanFailedOnlyHistoryUnderRunsRetention() {
-		// RUNS retention treats an import as "successful" only if it has a non-ERROR item.
-		// When every stopped import is failed, no import qualifies for protection. Cleanup
-		// must still make progress — otherwise an environment that has only ever produced
-		// failed imports would accumulate error items and import rows forever.
+	public void runCleanup_shouldRetainNMostRecentImportsRegardlessOfState() {
+		// With no successful imports in history (so the pin is empty), the N most
+		// recent failed imports are still retained because RUNS counts every stopped
+		// import. Only the imports outside the window get cleaned.
 		Import import1 = createAndFailImport("error 1");
 		importService.saveItem(createErrorItem(import1, "/orgs/test/concepts/1/", "uuid-1"));
 
@@ -319,18 +317,59 @@ public class ItemCleanupServiceTest extends BaseModuleContextSensitiveTest {
 
 		int deleted = cleanupService.runCleanup();
 
-		// All three ERROR items go: none qualifies as latest-non-error-per-URL.
-		assertThat(deleted, is(3));
+		// Only import1 is outside the window — its ERROR item gets cleaned, and the
+		// now-empty import is swept by the orphan pass.
+		assertThat(deleted, is(1));
 
-		// All three imports become orphans (zero items) and get swept.
 		List<Import> remaining = importService.getImportsInOrder(0, 1000);
 		Set<Long> remainingIds = new HashSet<>();
 		for (Import i : remaining) {
 			remainingIds.add(i.getImportId());
 		}
 		assertThat(remainingIds.contains(import1.getImportId()), is(false));
-		assertThat(remainingIds.contains(import2.getImportId()), is(false));
-		assertThat(remainingIds.contains(import3.getImportId()), is(false));
+		assertThat(remainingIds.contains(import2.getImportId()), is(true));
+		assertThat(remainingIds.contains(import3.getImportId()), is(true));
+	}
+
+	@Test
+	public void runCleanup_shouldPinLatestSuccessfulImportEvenWhenOlderThanRunsWindow() {
+		// The latest successful import must survive even if a run of failures has
+		// pushed it outside the RUNS window. Without this pin, the next import would
+		// have no "last successful" timestamp to resume incremental updates from and
+		// would have to refetch everything.
+		Import oldSuccess = createAndStopImport();
+		importService.saveItem(createItem(oldSuccess, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import failed1 = createAndFailImport("error 1");
+		importService.saveItem(createErrorItem(failed1, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import failed2 = createAndFailImport("error 2");
+		importService.saveItem(createErrorItem(failed2, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import failed3 = createAndFailImport("error 3");
+		importService.saveItem(createErrorItem(failed3, "/orgs/test/concepts/1/", "uuid-1"));
+
+		// RUNS=2 → top 2 by importId are failed2 and failed3. failed1 sits between
+		// the retain window and the pinned oldSuccess, so it gets cleaned.
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "2");
+
+		int deleted = cleanupService.runCleanup();
+
+		assertThat(deleted, is(1));
+		assertThat(importService.getImportItems(oldSuccess, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(failed2, 0, 100, new HashSet<>()).size(), is(1));
+		assertThat(importService.getImportItems(failed3, 0, 100, new HashSet<>()).size(), is(1));
+
+		List<Import> remaining = importService.getImportsInOrder(0, 1000);
+		Set<Long> remainingIds = new HashSet<>();
+		for (Import i : remaining) {
+			remainingIds.add(i.getImportId());
+		}
+		assertThat(remainingIds.contains(oldSuccess.getImportId()), is(true));
+		assertThat(remainingIds.contains(failed1.getImportId()), is(false));
+		assertThat(remainingIds.contains(failed2.getImportId()), is(true));
+		assertThat(remainingIds.contains(failed3.getImportId()), is(true));
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/openconceptlab/ItemCleanupServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/ItemCleanupServiceTest.java
@@ -300,6 +300,40 @@ public class ItemCleanupServiceTest extends BaseModuleContextSensitiveTest {
 	}
 
 	@Test
+	public void runCleanup_shouldCleanFailedOnlyHistoryUnderRunsRetention() {
+		// RUNS retention treats an import as "successful" only if it has a non-ERROR item.
+		// When every stopped import is failed, no import qualifies for protection. Cleanup
+		// must still make progress — otherwise an environment that has only ever produced
+		// failed imports would accumulate error items and import rows forever.
+		Import import1 = createAndFailImport("error 1");
+		importService.saveItem(createErrorItem(import1, "/orgs/test/concepts/1/", "uuid-1"));
+
+		Import import2 = createAndFailImport("error 2");
+		importService.saveItem(createErrorItem(import2, "/orgs/test/concepts/2/", "uuid-2"));
+
+		Import import3 = createAndFailImport("error 3");
+		importService.saveItem(createErrorItem(import3, "/orgs/test/concepts/3/", "uuid-3"));
+
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETENTION_TYPE, "RUNS");
+		setGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_RETAIN_IMPORTS, "2");
+
+		int deleted = cleanupService.runCleanup();
+
+		// All three ERROR items go: none qualifies as latest-non-error-per-URL.
+		assertThat(deleted, is(3));
+
+		// All three imports become orphans (zero items) and get swept.
+		List<Import> remaining = importService.getImportsInOrder(0, 1000);
+		Set<Long> remainingIds = new HashSet<>();
+		for (Import i : remaining) {
+			remainingIds.add(i.getImportId());
+		}
+		assertThat(remainingIds.contains(import1.getImportId()), is(false));
+		assertThat(remainingIds.contains(import2.getImportId()), is(false));
+		assertThat(remainingIds.contains(import3.getImportId()), is(false));
+	}
+
+	@Test
 	public void runCleanup_shouldDeleteItemsFromImportsOlderThanRetainedDays() {
 		// Create an old import with two concepts
 		Import oldImport = createAndStopImport();

--- a/api/src/test/java/org/openmrs/module/openconceptlab/scheduler/CleanupSchedulerTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/scheduler/CleanupSchedulerTest.java
@@ -1,0 +1,134 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.openconceptlab.scheduler;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.module.openconceptlab.ItemCleanupService;
+import org.openmrs.module.openconceptlab.OpenConceptLabConstants;
+import org.openmrs.test.BaseContextMockTest;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.Date;
+import java.util.concurrent.ScheduledFuture;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CleanupSchedulerTest extends BaseContextMockTest {
+
+	@Mock
+	ThreadPoolTaskScheduler scheduler;
+
+	@Mock
+	ItemCleanupService cleanupService;
+
+	@Mock
+	AdministrationService adminService;
+
+	// Not @Mock — created manually to prevent @InjectMocks from injecting it
+	// into CleanupScheduler's scheduledCleanup field by type
+	ScheduledFuture<?> scheduledFuture;
+
+	@InjectMocks
+	CleanupScheduler cleanupScheduler;
+
+	@Before
+	public void before() {
+		scheduledFuture = Mockito.mock(ScheduledFuture.class);
+		doReturn(scheduledFuture).when(scheduler).schedule(any(Runnable.class), any(Date.class));
+	}
+
+	@Test
+	public void scheduleCleanup_shouldScheduleWithDefaultDelay() {
+		when(adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_DELAY_MINUTES)).thenReturn(null);
+
+		long before = System.currentTimeMillis() + (5 * 60 * 1000L);
+		cleanupScheduler.scheduleCleanup();
+		long after = System.currentTimeMillis() + (5 * 60 * 1000L);
+
+		ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+		verify(scheduler).schedule(any(Runnable.class), dateCaptor.capture());
+
+		long scheduledTime = dateCaptor.getValue().getTime();
+		assertThat(scheduledTime, greaterThanOrEqualTo(before));
+		assertThat(scheduledTime, lessThanOrEqualTo(after));
+	}
+
+	@Test
+	public void scheduleCleanup_shouldScheduleWithConfiguredDelay() {
+		when(adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_DELAY_MINUTES)).thenReturn("10");
+
+		long before = System.currentTimeMillis() + (10 * 60 * 1000L);
+		cleanupScheduler.scheduleCleanup();
+		long after = System.currentTimeMillis() + (10 * 60 * 1000L);
+
+		ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+		verify(scheduler).schedule(any(Runnable.class), dateCaptor.capture());
+
+		long scheduledTime = dateCaptor.getValue().getTime();
+		assertThat(scheduledTime, greaterThanOrEqualTo(before));
+		assertThat(scheduledTime, lessThanOrEqualTo(after));
+	}
+
+	@Test
+	public void scheduleCleanup_shouldUseDefaultDelayForInvalidProperty() {
+		when(adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_DELAY_MINUTES)).thenReturn("not-a-number");
+
+		long before = System.currentTimeMillis() + (5 * 60 * 1000L);
+		cleanupScheduler.scheduleCleanup();
+		long after = System.currentTimeMillis() + (5 * 60 * 1000L);
+
+		ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+		verify(scheduler).schedule(any(Runnable.class), dateCaptor.capture());
+
+		long scheduledTime = dateCaptor.getValue().getTime();
+		assertThat(scheduledTime, greaterThanOrEqualTo(before));
+		assertThat(scheduledTime, lessThanOrEqualTo(after));
+	}
+
+	@Test
+	public void scheduleCleanup_shouldCancelPreviouslyScheduledCleanup() {
+		when(adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_DELAY_MINUTES)).thenReturn("5");
+		when(scheduledFuture.isDone()).thenReturn(false);
+
+		cleanupScheduler.scheduleCleanup();
+		cleanupScheduler.scheduleCleanup();
+
+		// First call schedules, second call cancels + reschedules
+		verify(scheduledFuture).cancel(false);
+		verify(scheduler, times(2)).schedule(any(Runnable.class), any(Date.class));
+	}
+
+	@Test
+	public void scheduleCleanup_shouldNotCancelAlreadyCompletedCleanup() {
+		when(adminService.getGlobalProperty(OpenConceptLabConstants.GP_CLEANUP_DELAY_MINUTES)).thenReturn("5");
+		when(scheduledFuture.isDone()).thenReturn(true);
+
+		cleanupScheduler.scheduleCleanup();
+		cleanupScheduler.scheduleCleanup();
+
+		// First completed, so second should not cancel it
+		verify(scheduledFuture, never()).cancel(false);
+		verify(scheduler, times(2)).schedule(any(Runnable.class), any(Date.class));
+	}
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -56,11 +56,11 @@
 	</globalProperty>
 	<globalProperty>
 		<property>openconceptlab.cleanupRetentionType</property>
-		<description>Item retention policy: RUNS (keep N most recent imports) or DAYS (keep imports within X days). Leave empty to disable cleanup.</description>
+		<description>Item retention policy: RUNS (keep N most recent successful imports, meaning imports with at least one non-ERROR item) or DAYS (keep imports within X days). Leave empty to disable cleanup.</description>
 	</globalProperty>
 	<globalProperty>
 		<property>openconceptlab.cleanupRetainImports</property>
-		<description>Number of most recent completed imports to retain (when using RUNS policy)</description>
+		<description>Number of most recent successful imports to retain (when using RUNS policy; successful means the import has at least one non-ERROR item)</description>
 		<defaultValue>3</defaultValue>
 	</globalProperty>
 	<globalProperty>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -54,6 +54,25 @@
 		<property>openconceptlab.token</property>
 		<description>The OCL API Token</description>
 	</globalProperty>
+	<globalProperty>
+		<property>openconceptlab.cleanupRetentionType</property>
+		<description>Item retention policy: RUNS (keep N most recent imports) or DAYS (keep imports within X days). Leave empty to disable cleanup.</description>
+	</globalProperty>
+	<globalProperty>
+		<property>openconceptlab.cleanupRetainImports</property>
+		<description>Number of most recent completed imports to retain (when using RUNS policy)</description>
+		<defaultValue>3</defaultValue>
+	</globalProperty>
+	<globalProperty>
+		<property>openconceptlab.cleanupRetainDays</property>
+		<description>Number of days to retain import data (when using DAYS policy)</description>
+		<defaultValue>30</defaultValue>
+	</globalProperty>
+	<globalProperty>
+		<property>openconceptlab.cleanupDelayMinutes</property>
+		<description>Minutes to wait after import completion before running cleanup (debounce period)</description>
+		<defaultValue>5</defaultValue>
+	</globalProperty>
 
 	<!-- Maps hibernate file's, if present -->
 	<mappingFiles>


### PR DESCRIPTION
The goal here is to add a clean-up task that removes old imports in a somewhat configurable way. Basically, via GP, it's possible to specify a number of _days_ or a number of _runs_ that should be preserved. 

Regardless, the clean-up will preserve _at least one non-errored item for each URL_ so that the lookup via OCL URLs will continue to work.

This is a draft because it needs some testing and some clean-up.