### PR TITLE
OCLOMRS-1122: Decode any HTML-encoding of the key

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/ImportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/ImportServiceImpl.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.openconceptlab;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.criterion.Order;
@@ -363,13 +364,13 @@ public class ImportServiceImpl implements ImportService {
 			return null;
 		}
 		Subscription subscription = new Subscription();
-		subscription.setUrl(url);
+		subscription.setUrl(StringEscapeUtils.unescapeHtml4(url));
 
 		String uuid = adminService.getGlobalProperty(OpenConceptLabConstants.GP_SUBSCRIPTION_UUID);
 		subscription.setUuid(uuid);
 
 		String token = adminService.getGlobalProperty(OpenConceptLabConstants.GP_TOKEN);
-		subscription.setToken(token);
+		subscription.setToken(StringEscapeUtils.unescapeHtml4(token));
 
 		String validationType = adminService.getGlobalProperty(OpenConceptLabConstants.GP_VALIDATION_TYPE);
 		if (StringUtils.isNotBlank(validationType)) {

--- a/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/ImportServiceTest.java
@@ -200,6 +200,27 @@ public class ImportServiceTest extends BaseModuleContextSensitiveTest {
 		assertThat(subscription, is(newSubscription));
 	}
 
+	/**
+	 * @see ImportServiceImpl#getSubscription()
+	 * @Verifies unescapes HTML entities in token and URL from global properties
+	 */
+	@Test
+	public void getSubscription_shouldUnescapeHtmlEntitiesInTokenAndUrl() throws Exception {
+		String escapedToken = "abc&amp;def&lt;ghi";
+		String expectedToken = "abc&def<ghi";
+		String escapedUrl = "http://api.openconceptlab.com/orgs/test?a=1&amp;b=2";
+		String expectedUrl = "http://api.openconceptlab.com/orgs/test?a=1&b=2";
+
+		Context.getAdministrationService()
+				.setGlobalProperty(OpenConceptLabConstants.GP_SUBSCRIPTION_URL, escapedUrl);
+		Context.getAdministrationService()
+				.setGlobalProperty(OpenConceptLabConstants.GP_TOKEN, escapedToken);
+
+		Subscription subscription = importService.getSubscription();
+		assertThat(subscription.getUrl(), is(expectedUrl));
+		assertThat(subscription.getToken(), is(expectedToken));
+	}
+
     /*
      * These ignored tests are working fine,
      * but it takes too much time to finish them


### PR DESCRIPTION
Recently, it's been reported that some users are experiencing issues with the OCL subscription workflow that result in getting a 401 response even when everything looks correct. I suspect the issue relates to some of the XSS work we did last year, so this undoes that. I have not, however, done any rigorous attempt to prove that is the issue. In either case, this is pretty harmless.