### PR TITLE
OCLOMRS-1124: Use v5 UUIDs for ConceptClasses in OCL imports

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -195,6 +195,7 @@ public class Saver {
 			conceptClass = new ConceptClass();
 			conceptClass.setName(oclConcept.getConceptClass());
 			conceptClass.setDescription("Imported from Open Concept Lab");
+			conceptClass.setUuid(version5Uuid("conceptClass/" + oclConcept.getConceptClass()).toString());
 			conceptService.saveConceptClass(conceptClass);
 		}
 		concept.setConceptClass(conceptClass);

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -710,6 +710,30 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		ConceptClass conceptClass = conceptService.getConceptClassByName(concept.getConceptClass());
 		assertThat(conceptClass, notNullValue());
+		assertThat(conceptClass.getUuid(), is(version5Uuid("conceptClass/" + concept.getConceptClass()).toString()));
+	}
+	
+	/**
+	 * @verifies generate deterministic UUID for new concept class
+	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
+	 */
+	@Test
+	public void importConcept_shouldGenerateDeterministicUuidForNewConceptClass() throws Exception {
+		Import update = importService.getLastImport();
+		String className = "Drug route";
+		String expectedUuid = version5Uuid("conceptClass/" + className).toString();
+		
+		OclConcept concept = newOclConcept();
+		concept.setConceptClass(className);
+		
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept);
+		
+		ConceptClass conceptClass = conceptService.getConceptClassByName(className);
+		assertThat(conceptClass, notNullValue());
+		assertThat(conceptClass.getUuid(), is(expectedUuid));
+		
+		// Verify determinism: calling version5Uuid again with the same seed produces the same UUID
+		assertThat(version5Uuid("conceptClass/" + className).toString(), is(expectedUuid));
 	}
 
 	/**


### PR DESCRIPTION
### Issue
When the OCL module creates a new ConceptClass during import , the UUID is randomly generated. This means different OpenMRS instances importing the same OCL source end up with different UUIDs for the same concept class, breaking data synchronization (dbsync, Initializer) and making portable configuration impossible.

### Fix
Generate a deterministic version 5 (name-based) UUID for newly created ConceptClass entities using:

`conceptClass.setUuid(version5Uuid("conceptClass/" + name).toString());`


Changes:

Saver.java — Added setUuid(...) call when creating a new ConceptClass
SaverTest.java — Enhanced existing test to verify UUID is deterministic; added new test using "Drug route" as the class name to confirm consistent UUID generation
Existing concept classes already in the database are not affected.