### PR TITLE
OCLOMRS-1126: Propagate `retired` and `retire_reason` from OCL when importing concepts and mappings

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabConstants.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/OpenConceptLabConstants.java
@@ -38,4 +38,9 @@ public class OpenConceptLabConstants {
 	public static final String GP_OCL_LOAD_AT_STARTUP_PATH = MODULE_ID + ".oclLoadAtStartupPath";
 
 	public static final UUID OPEN_CONCEPT_LAB_NAMESPACE_UUID = UUID.fromString("672c6cb2-4f47-4cb0-9fca-b5f6116cd33a");
+
+	/**
+	 * Default retire reason
+	 */
+	public static final String DEFAULT_RETIRE_REASON = "Retired in OCL";
 }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclConcept.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclConcept.java
@@ -45,6 +45,9 @@ public class OclConcept {
 
 	private boolean retired;
 
+	@JsonProperty("retire_reason")
+	private String retireReason;
+
 	private String url;
 
 	@JsonProperty("version_url")
@@ -133,6 +136,14 @@ public class OclConcept {
 
 	public void setRetired(boolean retired) {
 		this.retired = retired;
+	}
+
+	public String getRetireReason() {
+		return retireReason;
+	}
+
+	public void setRetireReason(String retireReason) {
+		this.retireReason = retireReason;
 	}
 
 	public String getUrl() {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclConcept.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclConcept.java
@@ -222,6 +222,11 @@ public class OclConcept {
 
 		private String type;
 
+		private Boolean retired;
+
+		@JsonProperty("retire_reason")
+		private String retireReason;
+
 		public String getUuid() {
 			return uuid;
 		}
@@ -278,6 +283,26 @@ public class OclConcept {
 			this.type = type;
 		}
 
+		public Boolean getRetired() {
+			return retired;
+		}
+
+		public boolean isRetired() {
+			return Boolean.TRUE.equals(retired);
+		}
+
+		public void setRetired(Boolean retired) {
+			this.retired = retired;
+		}
+
+		public String getRetireReason() {
+			return retireReason;
+		}
+
+		public void setRetireReason(String retireReason) {
+			this.retireReason = retireReason;
+		}
+
 		@Override
 		public String toString() {
 			return new ToStringBuilder(this).append("name", name).build();
@@ -324,6 +349,11 @@ public class OclConcept {
 
 		private String description;
 
+		private Boolean retired;
+
+		@JsonProperty("retire_reason")
+		private String retireReason;
+
 		public String getUuid() {
 			return uuid;
 		}
@@ -354,6 +384,26 @@ public class OclConcept {
 
 		public void setDescription(String description) {
 			this.description = description;
+		}
+
+		public Boolean getRetired() {
+			return retired;
+		}
+
+		public boolean isRetired() {
+			return Boolean.TRUE.equals(retired);
+		}
+
+		public void setRetired(Boolean retired) {
+			this.retired = retired;
+		}
+
+		public String getRetireReason() {
+			return retireReason;
+		}
+
+		public void setRetireReason(String retireReason) {
+			this.retireReason = retireReason;
 		}
 
 		public void copyFrom(ConceptDescription description) {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclConcept.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclConcept.java
@@ -203,14 +203,7 @@ public class OclConcept {
 	}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)
-	public static class Name {
-
-		private String uuid;
-
-		@JsonProperty("external_id")
-		private String externalId;
-
-		private Locale locale;
+	public static class Name extends OclLocalizedObject {
 
 		@JsonProperty("locale_preferred")
 		private boolean localePreferred;
@@ -221,35 +214,6 @@ public class OclConcept {
 		private String nameType;
 
 		private String type;
-
-		private Boolean retired;
-
-		@JsonProperty("retire_reason")
-		private String retireReason;
-
-		public String getUuid() {
-			return uuid;
-		}
-
-		public void setUuid(String uuid) {
-			this.uuid = uuid;
-		}
-
-		public String getExternalId() {
-			return externalId;
-		}
-
-		public void setExternalId(String externalId) {
-			this.externalId = externalId;
-		}
-
-		public Locale getLocale() {
-			return locale;
-		}
-
-		public void setLocale(Locale locale) {
-			this.locale = locale;
-		}
 
 		public boolean isLocalePreferred() {
 			return localePreferred;
@@ -283,26 +247,6 @@ public class OclConcept {
 			this.type = type;
 		}
 
-		public Boolean getRetired() {
-			return retired;
-		}
-
-		public boolean isRetired() {
-			return Boolean.TRUE.equals(retired);
-		}
-
-		public void setRetired(Boolean retired) {
-			this.retired = retired;
-		}
-
-		public String getRetireReason() {
-			return retireReason;
-		}
-
-		public void setRetireReason(String retireReason) {
-			this.retireReason = retireReason;
-		}
-
 		@Override
 		public String toString() {
 			return new ToStringBuilder(this).append("name", name).build();
@@ -310,7 +254,7 @@ public class OclConcept {
 
 		@Override
 		public int hashCode() {
-			return new HashCodeBuilder().append(locale).append(localePreferred).append(name).append(nameType).build();
+			return new HashCodeBuilder().append(getLocale()).append(localePreferred).append(name).append(nameType).build();
 		}
 
 		@Override
@@ -325,58 +269,22 @@ public class OclConcept {
 				return false;
 			}
 			Name rhs = (Name) obj;
-			return new EqualsBuilder().append(locale, rhs.locale).append(localePreferred, rhs.localePreferred)
+			return new EqualsBuilder().append(getLocale(), rhs.getLocale()).append(localePreferred, rhs.localePreferred)
 			        .append(name, rhs.name).append(nameType, rhs.nameType).build();
 		}
 
 		public void copyFrom(ConceptName name) {
 			this.name = name.getName();
-			locale = name.getLocale();
+			setLocale(name.getLocale());
 			localePreferred = name.getLocalePreferred() != null ? name.getLocalePreferred() : false;
 			nameType = name.getConceptNameType() != null ? name.getConceptNameType().toString() : null;
 		}
 	}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)
-	public static class Description {
-
-		private String uuid;
-
-		@JsonProperty("external_id")
-		private String externalId;
-
-		private Locale locale;
+	public static class Description extends OclLocalizedObject {
 
 		private String description;
-
-		private Boolean retired;
-
-		@JsonProperty("retire_reason")
-		private String retireReason;
-
-		public String getUuid() {
-			return uuid;
-		}
-
-		public void setUuid(String uuid) {
-			this.uuid = uuid;
-		}
-
-		public String getExternalId() {
-			return externalId;
-		}
-
-		public void setExternalId(String externalId) {
-			this.externalId = externalId;
-		}
-
-		public Locale getLocale() {
-			return locale;
-		}
-
-		public void setLocale(Locale locale) {
-			this.locale = locale;
-		}
 
 		public String getDescription() {
 			return description;
@@ -386,34 +294,14 @@ public class OclConcept {
 			this.description = description;
 		}
 
-		public Boolean getRetired() {
-			return retired;
-		}
-
-		public boolean isRetired() {
-			return Boolean.TRUE.equals(retired);
-		}
-
-		public void setRetired(Boolean retired) {
-			this.retired = retired;
-		}
-
-		public String getRetireReason() {
-			return retireReason;
-		}
-
-		public void setRetireReason(String retireReason) {
-			this.retireReason = retireReason;
-		}
-
 		public void copyFrom(ConceptDescription description) {
 			this.description = description.getDescription();
-			locale = description.getLocale();
+			setLocale(description.getLocale());
 		}
 
 		@Override
 		public int hashCode() {
-			return new HashCodeBuilder().append(locale).append(description).build();
+			return new HashCodeBuilder().append(getLocale()).append(description).build();
 		}
 
 		@Override
@@ -428,12 +316,12 @@ public class OclConcept {
 				return false;
 			}
 			Description rhs = (Description) obj;
-			return new EqualsBuilder().append(locale, rhs.locale).append(description, rhs.description).build();
+			return new EqualsBuilder().append(getLocale(), rhs.getLocale()).append(description, rhs.description).build();
 		}
 
 		@Override
 		public String toString() {
-			return new ToStringBuilder(this).append("description", description).append("locale", locale).build();
+			return new ToStringBuilder(this).append("description", description).append("locale", getLocale()).build();
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclLocalizedObject.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclLocalizedObject.java
@@ -1,0 +1,73 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.openconceptlab.client;
+
+import java.util.Locale;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public abstract class OclLocalizedObject {
+
+	private String uuid;
+
+	@JsonProperty("external_id")
+	private String externalId;
+
+	private Locale locale;
+
+	private Boolean retired;
+
+	@JsonProperty("retire_reason")
+	private String retireReason;
+
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public String getExternalId() {
+		return externalId;
+	}
+
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
+	}
+
+	public Locale getLocale() {
+		return locale;
+	}
+
+	public void setLocale(Locale locale) {
+		this.locale = locale;
+	}
+
+	public Boolean getRetired() {
+		return retired;
+	}
+
+	public boolean isRetired() {
+		return Boolean.TRUE.equals(retired);
+	}
+
+	public void setRetired(Boolean retired) {
+		this.retired = retired;
+	}
+
+	public String getRetireReason() {
+		return retireReason;
+	}
+
+	public void setRetireReason(String retireReason) {
+		this.retireReason = retireReason;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -108,6 +108,7 @@ public class OclMapping {
 	public void setRetired(Boolean retired) {
 		this.retired = retired;
 	}
+
 	
 	public String getMapType() {
 		return mapType;

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclMapping.java
@@ -108,7 +108,6 @@ public class OclMapping {
 	public void setRetired(Boolean retired) {
 		this.retired = retired;
 	}
-
 	
 	public String getMapType() {
 		return mapType;

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -186,7 +186,7 @@ public class Saver {
 			oclConcept.setExternalId(version5Uuid(oclConcept.getUrl()).toString());
 			concept = cacheService.getConceptByUuid(oclConcept.getExternalId());
 		}
-		
+
 		if (concept == null) {
 			if (datatype.getUuid().equals(ConceptDatatype.NUMERIC_UUID)) {
 				concept = new ConceptNumeric();
@@ -381,7 +381,7 @@ public class Saver {
 						if (toItem != null) {
 							toConcept = cacheService.getConceptByUuid(toItem.getUuid());
 						}
-						
+
 						if (toConcept == null) {
 							String source = oclMapping.getToSourceName();
 							String code = oclMapping.getToConceptCode();
@@ -620,7 +620,7 @@ public class Saver {
 		if (sortWeight != null) {
 			return sortWeight;
 		}
-		
+
 		return defaultIfUndefined;
 	}
 

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -738,18 +738,13 @@ public class Saver {
 	void addDescriptionsFromOcl(Concept concept, OclConcept oclConcept) {
 		if (oclConcept.getDescriptions() != null) {
 			for (Description oclDescription : oclConcept.getDescriptions()) {
-                if (StringUtils.isBlank(oclDescription.getDescription())) {
-                    continue;
-                }
-
-                if (oclDescription.isRetired()) {
+                if (StringUtils.isBlank(oclDescription.getDescription()) || oclDescription.isRetired()) {
                     continue;
                 }
 
                 boolean descriptionFound = false;
                 for (ConceptDescription description : concept.getDescriptions()) {
                     if (isMatch(oclDescription, description)) {
-                        //Let's make sure all is the same
                         description.setDescription(oclDescription.getDescription());
                         description.setLocale(oclDescription.getLocale());
                         descriptionFound = true;
@@ -760,11 +755,11 @@ public class Saver {
                 if (!descriptionFound) {
                     ConceptDescription description = new ConceptDescription(oclDescription.getDescription(),
                             oclDescription.getLocale());
-	                if (oclDescription.getExternalId() != null) {
-		                description.setUuid(oclDescription.getExternalId());
-	                } else {
-		                description.setUuid(version5Uuid(oclConcept.getUrl() + "/descriptions/" + oclDescription.getUuid()).toString());
-	                }
+                    if (oclDescription.getExternalId() != null) {
+                        description.setUuid(oclDescription.getExternalId());
+                    } else {
+                        description.setUuid(version5Uuid(oclConcept.getUrl() + "/descriptions/" + oclDescription.getUuid()).toString());
+                    }
                     concept.addDescription(description);
                 }
             }

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -186,6 +186,7 @@ public class Saver {
 			oclConcept.setExternalId(version5Uuid(oclConcept.getUrl()).toString());
 			concept = cacheService.getConceptByUuid(oclConcept.getExternalId());
 		}
+		
 		if (concept == null) {
 			if (datatype.getUuid().equals(ConceptDatatype.NUMERIC_UUID)) {
 				concept = new ConceptNumeric();
@@ -232,7 +233,7 @@ public class Saver {
 		concept.setRetired(oclConcept.isRetired());
 		if (oclConcept.isRetired()) {
 			if (StringUtils.isNotBlank(oclConcept.getRetireReason())) {
-				concept.setRetireReason(oclConcept.getRetireReason());
+				concept.setRetireReason(StringUtils.abbreviate(oclConcept.getRetireReason(), 255));
 			} else {
 				concept.setRetireReason(OpenConceptLabConstants.DEFAULT_RETIRE_REASON);
 			}
@@ -380,6 +381,7 @@ public class Saver {
 						if (toItem != null) {
 							toConcept = cacheService.getConceptByUuid(toItem.getUuid());
 						}
+						
 						if (toConcept == null) {
 							String source = oclMapping.getToSourceName();
 							String code = oclMapping.getToConceptCode();
@@ -618,6 +620,7 @@ public class Saver {
 		if (sortWeight != null) {
 			return sortWeight;
 		}
+		
 		return defaultIfUndefined;
 	}
 

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -33,6 +33,7 @@ import org.openmrs.module.openconceptlab.Import;
 import org.openmrs.module.openconceptlab.ImportService;
 import org.openmrs.module.openconceptlab.Item;
 import org.openmrs.module.openconceptlab.ItemState;
+import org.openmrs.module.openconceptlab.OpenConceptLabConstants;
 import org.openmrs.module.openconceptlab.Utils;
 import org.openmrs.module.openconceptlab.ValidationType;
 import org.openmrs.module.openconceptlab.client.OclConcept;
@@ -185,7 +186,6 @@ public class Saver {
 			oclConcept.setExternalId(version5Uuid(oclConcept.getUrl()).toString());
 			concept = cacheService.getConceptByUuid(oclConcept.getExternalId());
 		}
-		
 		if (concept == null) {
 			if (datatype.getUuid().equals(ConceptDatatype.NUMERIC_UUID)) {
 				concept = new ConceptNumeric();
@@ -231,7 +231,11 @@ public class Saver {
 
 		concept.setRetired(oclConcept.isRetired());
 		if (oclConcept.isRetired()) {
-			concept.setRetireReason("Retired in OCL");
+			if (StringUtils.isNotBlank(oclConcept.getRetireReason())) {
+				concept.setRetireReason(oclConcept.getRetireReason());
+			} else {
+				concept.setRetireReason(OpenConceptLabConstants.DEFAULT_RETIRE_REASON);
+			}
 		} else {
 			concept.setRetireReason(null);
 			concept.setRetiredBy(null);
@@ -376,7 +380,6 @@ public class Saver {
 						if (toItem != null) {
 							toConcept = cacheService.getConceptByUuid(toItem.getUuid());
 						}
-						
 						if (toConcept == null) {
 							String source = oclMapping.getToSourceName();
 							String code = oclMapping.getToConceptCode();
@@ -615,7 +618,6 @@ public class Saver {
 		if (sortWeight != null) {
 			return sortWeight;
 		}
-		
 		return defaultIfUndefined;
 	}
 

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -738,31 +738,31 @@ public class Saver {
 	void addDescriptionsFromOcl(Concept concept, OclConcept oclConcept) {
 		if (oclConcept.getDescriptions() != null) {
 			for (Description oclDescription : oclConcept.getDescriptions()) {
-                if (StringUtils.isBlank(oclDescription.getDescription()) || oclDescription.isRetired()) {
-                    continue;
-                }
+				if (StringUtils.isBlank(oclDescription.getDescription()) || oclDescription.isRetired()) {
+					continue;
+				}
 
-                boolean descriptionFound = false;
-                for (ConceptDescription description : concept.getDescriptions()) {
-                    if (isMatch(oclDescription, description)) {
-                        description.setDescription(oclDescription.getDescription());
-                        description.setLocale(oclDescription.getLocale());
-                        descriptionFound = true;
-                        break;
-                    }
-                }
+				boolean descriptionFound = false;
+				for (ConceptDescription description : concept.getDescriptions()) {
+					if (isMatch(oclDescription, description)) {
+						description.setDescription(oclDescription.getDescription());
+						description.setLocale(oclDescription.getLocale());
+						descriptionFound = true;
+						break;
+					}
+				}
 
-                if (!descriptionFound) {
-                    ConceptDescription description = new ConceptDescription(oclDescription.getDescription(),
-                            oclDescription.getLocale());
-                    if (oclDescription.getExternalId() != null) {
-                        description.setUuid(oclDescription.getExternalId());
-                    } else {
-                        description.setUuid(version5Uuid(oclConcept.getUrl() + "/descriptions/" + oclDescription.getUuid()).toString());
-                    }
-                    concept.addDescription(description);
-                }
-            }
+				if (!descriptionFound) {
+					ConceptDescription description = new ConceptDescription(oclDescription.getDescription(),
+							oclDescription.getLocale());
+					if (oclDescription.getExternalId() != null) {
+						description.setUuid(oclDescription.getExternalId());
+					} else {
+						description.setUuid(version5Uuid(oclConcept.getUrl() + "/descriptions/" + oclDescription.getUuid()).toString());
+					}
+					concept.addDescription(description);
+				}
+			}
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -644,10 +644,17 @@ public class Saver {
 					name.setConceptNameType(oclNameType);
 					name.setLocalePreferred(oclName.isLocalePreferred());
 
-					//Unvoiding if necessary
-					name.setVoided(false);
-					name.setVoidReason(null);
-					name.setVoidedBy(null);
+					name.setVoided(oclName.isRetired());
+					if (oclName.isRetired()) {
+						if (StringUtils.isNotBlank(oclName.getRetireReason())) {
+							name.setVoidReason(StringUtils.abbreviate(oclName.getRetireReason(), 255));
+						} else {
+							name.setVoidReason(OpenConceptLabConstants.DEFAULT_RETIRE_REASON);
+						}
+					} else {
+						name.setVoidReason(null);
+						name.setVoidedBy(null);
+					}
 
 					nameFound = true;
 					break;
@@ -663,6 +670,14 @@ public class Saver {
 				}
 				name.setConceptNameType(oclNameType);
 				name.setLocalePreferred(oclName.isLocalePreferred());
+				if (oclName.isRetired()) {
+					name.setVoided(true);
+					if (StringUtils.isNotBlank(oclName.getRetireReason())) {
+						name.setVoidReason(StringUtils.abbreviate(oclName.getRetireReason(), 255));
+					} else {
+						name.setVoidReason(OpenConceptLabConstants.DEFAULT_RETIRE_REASON);
+					}
+				}
 				concept.addName(name);
 			}
 		}
@@ -727,6 +742,10 @@ public class Saver {
                     continue;
                 }
 
+                if (oclDescription.isRetired()) {
+                    continue;
+                }
+
                 boolean descriptionFound = false;
                 for (ConceptDescription description : concept.getDescriptions()) {
                     if (isMatch(oclDescription, description)) {
@@ -758,8 +777,7 @@ public class Saver {
 			boolean descriptionFound = false;
 			for (Description oclDescription : oclConcept.getDescriptions()) {
 				if (isMatch(oclDescription, description)) {
-					if (!StringUtils.isBlank(oclDescription.getDescription())) {
-						//Blank descriptions are invalid and will be removed
+					if (!StringUtils.isBlank(oclDescription.getDescription()) && !oclDescription.isRetired()) {
 						descriptionFound = true;
 					}
 					break;

--- a/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java
@@ -72,6 +72,14 @@ public class Saver {
 	    this.importService = importService;
     }
 
+	private String resolveRetireReason(String retireReason) {
+		if (StringUtils.isNotBlank(retireReason)) {
+			return StringUtils.abbreviate(retireReason, 255);
+		}
+		return OpenConceptLabConstants.DEFAULT_RETIRE_REASON;
+	}
+
+
 	public Item saveConcept(final CacheService cacheService, final Import anImport, final OclConcept oclConcept) throws ImportException {
 		return saveConcept(cacheService, anImport, oclConcept, null);
 	}
@@ -232,11 +240,7 @@ public class Saver {
 
 		concept.setRetired(oclConcept.isRetired());
 		if (oclConcept.isRetired()) {
-			if (StringUtils.isNotBlank(oclConcept.getRetireReason())) {
-				concept.setRetireReason(StringUtils.abbreviate(oclConcept.getRetireReason(), 255));
-			} else {
-				concept.setRetireReason(OpenConceptLabConstants.DEFAULT_RETIRE_REASON);
-			}
+			concept.setRetireReason(resolveRetireReason(oclConcept.getRetireReason()));
 		} else {
 			concept.setRetireReason(null);
 			concept.setRetiredBy(null);
@@ -646,11 +650,7 @@ public class Saver {
 
 					name.setVoided(oclName.isRetired());
 					if (oclName.isRetired()) {
-						if (StringUtils.isNotBlank(oclName.getRetireReason())) {
-							name.setVoidReason(StringUtils.abbreviate(oclName.getRetireReason(), 255));
-						} else {
-							name.setVoidReason(OpenConceptLabConstants.DEFAULT_RETIRE_REASON);
-						}
+						name.setVoidReason(resolveRetireReason(oclName.getRetireReason()));
 					} else {
 						name.setVoidReason(null);
 						name.setVoidedBy(null);
@@ -672,11 +672,7 @@ public class Saver {
 				name.setLocalePreferred(oclName.isLocalePreferred());
 				if (oclName.isRetired()) {
 					name.setVoided(true);
-					if (StringUtils.isNotBlank(oclName.getRetireReason())) {
-						name.setVoidReason(StringUtils.abbreviate(oclName.getRetireReason(), 255));
-					} else {
-						name.setVoidReason(OpenConceptLabConstants.DEFAULT_RETIRE_REASON);
-					}
+					name.setVoidReason(resolveRetireReason(oclName.getRetireReason()));
 				}
 				concept.addName(name);
 			}

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -1811,9 +1811,237 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertTrue(concept.getRetireReason().endsWith("..."));
 	}
 
+	@Test
+	public void saveConcept_shouldRetireNameWithReason() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		oclConcept.setVersionUrl(oclConcept.getVersionUrl() + "2/");
+		for (OclConcept.Name name : oclConcept.getNames()) {
+			if ("Second name".equals(name.getName()) && name.getNameType() == null) {
+				name.setRetired(true);
+				name.setRetireReason("Name is no longer valid");
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		for (ConceptName conceptName : concept.getNames(true)) {
+			if ("Second name".equals(conceptName.getName()) && conceptName.getConceptNameType() == null) {
+				assertTrue(conceptName.getVoided());
+				assertThat(conceptName.getVoidReason(), is("Name is no longer valid"));
+				break;
+			}
+		}
+	}
+
+	@Test
+	public void saveConcept_shouldUnretireNameAndClearReason() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+
+		for (OclConcept.Name name : oclConcept.getNames()) {
+			if ("Second name".equals(name.getName()) && name.getNameType() == null) {
+				name.setRetired(true);
+				name.setRetireReason("Name is no longer valid");
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		oclConcept.setVersionUrl(oclConcept.getVersionUrl() + "2/");
+		for (OclConcept.Name name : oclConcept.getNames()) {
+			if ("Second name".equals(name.getName()) && name.getNameType() == null) {
+				name.setRetired(false);
+				name.setRetireReason(null);
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		for (ConceptName conceptName : concept.getNames(true)) {
+			if ("Second name".equals(conceptName.getName()) && conceptName.getConceptNameType() == null) {
+				assertFalse(conceptName.getVoided());
+				assertThat(conceptName.getVoidReason(), is(nullValue()));
+				break;
+			}
+		}
+	}
+
+	@Test
+	public void saveConcept_shouldHandleNoRetireReasonForName() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		// Set a name as retired without a reason
+		for (OclConcept.Name name : oclConcept.getNames()) {
+			if ("Second name".equals(name.getName()) && name.getNameType() == null) {
+				name.setRetired(true);
+				name.setRetireReason(null);
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		for (ConceptName conceptName : concept.getNames(true)) {
+			if ("Second name".equals(conceptName.getName()) && conceptName.getConceptNameType() == null) {
+				assertTrue(conceptName.getVoided());
+				assertThat(conceptName.getVoidReason(), is(OpenConceptLabConstants.DEFAULT_RETIRE_REASON));
+				break;
+			}
+		}
+	}
+
+	@Test
+	public void saveConcept_shouldTruncateLongRetireReasonForName() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		String longReason = new String(new char[300]).replace('\0', 'x');
+		// Set a name as retired with a long reason
+		for (OclConcept.Name name : oclConcept.getNames()) {
+			if ("Second name".equals(name.getName()) && name.getNameType() == null) {
+				name.setRetired(true);
+				name.setRetireReason(longReason);
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		for (ConceptName conceptName : concept.getNames(true)) {
+			if ("Second name".equals(conceptName.getName()) && conceptName.getConceptNameType() == null) {
+				assertTrue(conceptName.getVoided());
+				assertThat(conceptName.getVoidReason().length(), is(255));
+				assertTrue(conceptName.getVoidReason().endsWith("..."));
+				break;
+			}
+		}
+	}
+
+	@Test
+	public void saveConcept_shouldVoidNameWhenReimportedAsRetired() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		for (ConceptName conceptName : concept.getNames(true)) {
+			if ("Second name".equals(conceptName.getName()) && conceptName.getConceptNameType() == null) {
+				assertFalse(conceptName.getVoided());
+				break;
+			}
+		}
+
+		oclConcept.setVersionUrl(oclConcept.getVersionUrl() + "2/");
+		for (OclConcept.Name name : oclConcept.getNames()) {
+			if ("Second name".equals(name.getName()) && name.getNameType() == null) {
+				name.setRetired(true);
+				name.setRetireReason("No longer needed in OCL");
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		for (ConceptName conceptName : concept.getNames(true)) {
+			if ("Second name".equals(conceptName.getName()) && conceptName.getConceptNameType() == null) {
+				assertTrue(conceptName.getVoided());
+				assertThat(conceptName.getVoidReason(), is("No longer needed in OCL"));
+				break;
+			}
+		}
+	}
+
+	@Test
+	public void saveConcept_shouldRemoveRetiredDescription() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		boolean foundDesc = false;
+		for (ConceptDescription desc : concept.getDescriptions()) {
+			if ("Test description".equals(desc.getDescription())) {
+				foundDesc = true;
+				break;
+			}
+		}
+		assertTrue(foundDesc);
+
+		oclConcept.setVersionUrl(oclConcept.getVersionUrl() + "2/");
+		for (OclConcept.Description oclDesc : oclConcept.getDescriptions()) {
+			if ("Test description".equals(oclDesc.getDescription())) {
+				oclDesc.setRetired(true);
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		for (ConceptDescription desc : concept.getDescriptions()) {
+			assertFalse("Test description".equals(desc.getDescription()));
+		}
+	}
+
+	@Test
+	public void saveConcept_shouldNotAddRetiredDescription() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+
+		for (OclConcept.Description oclDesc : oclConcept.getDescriptions()) {
+			if ("Test description".equals(oclDesc.getDescription())) {
+				oclDesc.setRetired(true);
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		for (ConceptDescription desc : concept.getDescriptions()) {
+			assertFalse("Test description".equals(desc.getDescription()));
+		}
+	}
 
 	@Test
 	public void saveMapping_shouldNotRetireReferenceTermWhenMappingIsRetired() throws Exception {
+		Import update = importService.getLastImport();
+
+		OclConcept oclConcept = newOclConcept();
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
+
+		// First create the mapping
+		OclMapping oclMapping = new OclMapping();
+		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+		oclMapping.setMapType("SAME-AS");
+		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
+		oclMapping.setToSourceName("SNOMED CT");
+		oclMapping.setToConceptCode("1001");
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
+
+		oclMapping.setRetired(true);
+		oclMapping.setUpdatedOn(new Date());
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		boolean found = false;
+		for (ConceptMap map : concept.getConceptMappings()) {
+			if ("1001".equals(map.getConceptReferenceTerm().getCode())) {
+				found = true;
+				break;
+			}
+		}
+		assertFalse(found);
+
+		ConceptSource source = conceptService.getConceptSourceByName("SNOMED CT");
+		ConceptReferenceTerm term = conceptService.getConceptReferenceTermByCode("1001", source);
+		assertFalse(BooleanUtils.isTrue(term.getRetired()));
+	}
+
+	@Test
+	public void saveMapping_shouldNotAddRetiredMapping() throws Exception {
 		Import update = importService.getLastImport();
 
 		OclConcept oclConcept = newOclConcept();
@@ -1831,7 +2059,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		ConceptSource source = conceptService.getConceptSourceByName("SNOMED CT");
 		ConceptReferenceTerm term = conceptService.getConceptReferenceTermByCode("1001", source);
-		assertFalse(term.getRetired());
+		assertFalse(BooleanUtils.isTrue(term.getRetired()));
 	}
 
 

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -87,6 +87,7 @@ import static org.junit.Assert.fail;
 import static org.openmrs.module.openconceptlab.Utils.version5Uuid;
 
 public class SaverTest extends BaseModuleContextSensitiveTest {
+
 	@Autowired
 	Saver saver;
 
@@ -98,15 +99,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Qualifier("openconceptlab.conceptService")
 	OclConceptService oclConceptService;
 
-	@Autowired
-	@Qualifier("openconceptlab.importService")
+	@Autowired @Qualifier("openconceptlab.importService")
 	ImportService importService;
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
 
-	private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-
+	private final SimpleDateFormat dateFormat = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss'Z'");
+	
 	private Import anImport;
 
 	@Before
@@ -120,7 +120,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void stopUpdate() {
 		importService.stopImport(importService.getLastImport());
 	}
-
+	
 	private Subscription generateSubscription() {
 		Subscription sub = new Subscription();
 		sub.setToken("token");
@@ -173,7 +173,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	/**
-	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
+	 * @see Saver#saveConcept(CacheService, Import, OclConcept) 
 	 * @verifies add new names to concept
 	 */
 	@Test
@@ -195,7 +195,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 	}
-
+	
 	private Name newFourthName() {
 		Name fourthName = new Name();
 		fourthName.setExternalId("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
@@ -205,7 +205,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		fourthName.setNameType(ConceptNameType.INDEX_TERM.toString());
 		return fourthName;
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies add new names to concept
@@ -214,6 +214,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldHandleNameTypesWithDashesCorrectly() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
+		
 		Name thirdName = new Name();
 		thirdName.setExternalId("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		thirdName.setName("Third name");
@@ -221,7 +222,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("Fully-Specified");
 		oclConcept.getNames().add(thirdName);
-
+		
 		Name fourthName = new Name();
 		fourthName.setExternalId("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
 		fourthName.setName("Fourth name");
@@ -229,14 +230,17 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		fourthName.setLocalePreferred(false);
 		fourthName.setNameType("Index-Term");
 		oclConcept.getNames().add(fourthName);
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
+		
 		ConceptName thirdConceptName = conceptService.getConceptNameByUuid("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		assertThat(thirdConceptName.getConceptNameType(), equalTo(ConceptNameType.FULLY_SPECIFIED));
+		
 		ConceptName fourthConceptName = conceptService.getConceptNameByUuid("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
 		assertThat(fourthConceptName.getConceptNameType(), equalTo(ConceptNameType.INDEX_TERM));
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -244,7 +248,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldHandleTheNoneNameTypeCorrectly() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
-
+		
 		Name thirdName = new Name();
 		thirdName.setExternalId("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		thirdName.setName("Third name");
@@ -252,12 +256,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("NONE");
 		oclConcept.getNames().add(thirdName);
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
+		
 		ConceptName thirdConceptName = conceptService.getConceptNameByUuid("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		assertThat(thirdConceptName.getConceptNameType(), nullValue());
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -265,7 +271,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAssignUuidToNameWithoutExternalId() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
-
+		
 		Name thirdName = new Name();
 		thirdName.setUuid("12345");
 		thirdName.setName("Third name");
@@ -273,13 +279,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("NONE");
 		oclConcept.getNames().add(thirdName);
-
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
-
+		
 		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
 		Collection<ConceptName> names = concept.getNames(false);
-
+		
 		ConceptName thirdConceptName = null;
 		for (ConceptName name : names) {
 			if (name.getName().equals("Third name")) {
@@ -287,13 +293,12 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 				break;
 			}
 		}
-
+		
 		if (thirdConceptName == null) {
 			fail("Concept " + concept.getUuid() + " did not have the name \"Third name\" loaded successfully");
 		}
-
-		assertThat(thirdConceptName.getUuid(),
-		    equalTo(version5Uuid(oclConcept.getUrl() + "/names/" + thirdName.getUuid()).toString()));
+		
+		assertThat(thirdConceptName.getUuid(), equalTo(version5Uuid(oclConcept.getUrl() + "/names/" + thirdName.getUuid()).toString()));
 	}
 
 	/**
@@ -383,7 +388,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
-	 * @verifies void old names when names are updated with different uuids
+	 * TODO: Not
 	 */
 	@Test
 	public void importConcept_shouldUpdateNamesWithDifferentUuids() throws Exception {
@@ -402,8 +407,8 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		List<Matcher<? super ConceptName>> matchers = new ArrayList<Matcher<? super ConceptName>>();
 		for (Name name : oclConcept.getNames()) {
 			ConceptNameType nameType = (name.getNameType() != null) ? ConceptNameType.valueOf(name.getNameType()) : null;
-			matchers.add(allOf(hasProperty("name", is(name.getName())), hasProperty("conceptNameType", is(nameType))));
-		}
+	        matchers.add(allOf(hasProperty("name", is(name.getName())), hasProperty("conceptNameType", is(nameType))));
+        }
 
 		assertThat(concept.getNames(false), containsInAnyOrder(matchers));
 		assertThat(concept.getNames(true).size(), is(6));
@@ -555,7 +560,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertImported(oclConcept);
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -563,15 +568,19 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAssignUuidToDescriptionWithoutExternalId() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
+		
 		Description desc1 = new Description();
 		desc1.setUuid("12345");
 		desc1.setDescription("test oclConceptDescription");
 		desc1.setLocale(Context.getLocale());
 		oclConcept.getDescriptions().add(desc1);
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
+		
 		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
 		Collection<ConceptDescription> descriptions = concept.getDescriptions();
+		
 		ConceptDescription conceptDescription = null;
 		for (ConceptDescription description : descriptions) {
 			if (description.getDescription().equals("test oclConceptDescription")) {
@@ -579,12 +588,12 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 				break;
 			}
 		}
+		
 		if (conceptDescription == null) {
-			fail("Concept " + concept.getUuid()
-			        + " did not have the description \"test oclConceptDescription\" loaded successfully");
+			fail("Concept " + concept.getUuid() + " did not have the description \"test oclConceptDescription\" loaded successfully");
 		}
-		assertThat(conceptDescription.getUuid(),
-		    equalTo(version5Uuid(oclConcept.getUrl() + "/descriptions/" + desc1.getUuid()).toString()));
+		
+		assertThat(conceptDescription.getUuid(), equalTo(version5Uuid(oclConcept.getUrl() + "/descriptions/" + desc1.getUuid()).toString()));
 	}
 
 	/**
@@ -704,7 +713,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(conceptClass, notNullValue());
 		assertThat(conceptClass.getUuid(), is(version5Uuid("conceptClass/" + concept.getConceptClass()).toString()));
 	}
-
+	
 	/**
 	 * @verifies generate deterministic UUID for new concept class
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
@@ -714,12 +723,17 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		String className = "Drug route";
 		String expectedUuid = version5Uuid("conceptClass/" + className).toString();
+		
 		OclConcept concept = newOclConcept();
 		concept.setConceptClass(className);
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept);
+		
 		ConceptClass conceptClass = conceptService.getConceptClassByName(className);
 		assertThat(conceptClass, notNullValue());
 		assertThat(conceptClass.getUuid(), is(expectedUuid));
+		
+		// Verify determinism: calling version5Uuid again with the same seed produces the same UUID
 		assertThat(version5Uuid("conceptClass/" + className).toString(), is(expectedUuid));
 	}
 
@@ -786,16 +800,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		Concept importedConceptWithIndexTerm = conceptService.getConceptByUuid(conceptWithSynonym.getExternalId());
 
-		assertThat(importedConcept.getNames(),
-		    hasItem((Matcher<? super ConceptName>) allOf(
-		        hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
-		        hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConcept.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
+			hasProperty("name", equalTo("Nazwa")))));
 
-		assertThat(importedConceptWithIndexTerm.getNames(),
-		    hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
-		        hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConceptWithIndexTerm.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
+			hasProperty("name", equalTo("Nazwa")))));
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies save concept if versionUrl changed from last anImport
@@ -805,18 +816,18 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		OclConcept concept = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept));
-
+		
 		OclConcept updateConcept = newOclConcept();
 		updateConcept.setVersionUrl(newOtherOclConcept().getVersionUrl());
 		updateConcept.setDatatype("Document");
-
+		
 		Item item = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, updateConcept);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UPDATED)));
-
+		
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		assertThat(importedConcept.getDatatype(), hasProperty("name", equalTo(updateConcept.getDatatype())));
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies skip saving concept if versionUrl didn't change from last anImport
@@ -826,13 +837,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		OclConcept concept = newOclConcept();
 		OclConcept updateConcept = newOclConcept();
-
+			
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept));
-
-		updateConcept.setDatatype("Document");
+		
+		updateConcept.setDatatype("Document");		
 		Item item = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, updateConcept);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UP_TO_DATE)));
-
+		
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		assertThat(importedConcept.getDatatype(), hasProperty("name", equalTo(concept.getDatatype())));
 	}
@@ -871,14 +882,11 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		Concept importedConceptWithIndexTerm = conceptService.getConceptByUuid(conceptWithSynonym.getExternalId());
 
-		assertThat(importedConcept.getNames(),
-		    hasItem((Matcher<? super ConceptName>) allOf(
-		        hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
-		        hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConcept.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
+			hasProperty("name", equalTo("Nazwa")))));
 
-		assertThat(importedConceptWithIndexTerm.getNames(),
-		    hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
-		        hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConceptWithIndexTerm.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
+			hasProperty("name", equalTo("Nazwa")))));
 	}
 
 	@Test
@@ -948,26 +956,26 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertThat(questionConcept.getAnswers(), contains(hasQuestionAndAnswer(questionConcept, answerConcept)));
 	}
-
+	
 	@Test
 	public void importMapping_shouldAddConceptAnswerWithSortWeight() throws Exception {
 		Import update = importService.getLastImport();
-
+		
 		OclConcept question = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, question));
-
+		
 		OclConcept answer = newOtherOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, answer));
-
+		
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType(MapType.Q_AND_A);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(356.0);
-
+		
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
-
+		
 		Concept questionConcept = conceptService.getConceptByUuid(question.getExternalId());
 		Concept answerConcept = conceptService.getConceptByUuid(answer.getExternalId());
 		List<ConceptAnswer> answers = answersForConcept(questionConcept, answerConcept);
@@ -1048,23 +1056,26 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(questionConcept.getAnswers(), not(contains(hasQuestionAndAnswer(questionConcept, answerConcept))));
 	}
 
+
 	@Test
 	public void importMapping_shouldUpdateConceptAnswer() throws Exception {
 		importMapping_shouldAddConceptAnswer();
 		Import update = importService.getLastImport();
+		
 		Concept questionConcept = conceptService.getConceptByUuid(newOclConcept().getExternalId());
 		Concept answerConcept = conceptService.getConceptByUuid(newOtherOclConcept().getExternalId());
+		
 		List<ConceptAnswer> answers = answersForConcept(questionConcept, answerConcept);
 		assertThat(answers.size(), is(1));
 		assertThat(answers.get(0).getSortWeight(), is(1.0)); // Concept Answers are given a sort weight in core if null
-
+		
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType(MapType.Q_AND_A);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(15.0);
-
+		
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		answers = answersForConcept(questionConcept, answerConcept);
 		assertThat(answers.size(), is(1));
@@ -1120,21 +1131,27 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertThat(setConcept.getSetMembers(), contains(memberConcept));
 	}
-
+	
 	@Test
 	public void importMapping_shouldAddConceptSetMemberWithSortWeight() throws Exception {
 		Import update = importService.getLastImport();
+		
 		OclConcept set = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, set));
+		
 		OclConcept member = newOtherOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, member));
+		
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+		
 		oclMapping.setMapType(MapType.SET);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(11.0);
+		
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
+		
 		Concept setConcept = conceptService.getConceptByUuid(set.getExternalId());
 		Concept memberConcept = conceptService.getConceptByUuid(member.getExternalId());
 		List<ConceptSet> members = membersForConceptSet(setConcept, memberConcept);
@@ -1354,6 +1371,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(cm.getConceptMapType(), equalTo(mapType));
 	}
 
+	
 	@Test
 	public void importMapping_shouldUpdateMappingOnylIfItHasBeenUpdatedSinceLastImport() throws Exception {
 		OclConcept oclConcept = newOclConcept();
@@ -1369,55 +1387,56 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setUrl("/orgs/CIELTEST/sources/CIELTEST/mappings/303");
 
 		importService.saveItem(saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping));
-
+		
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
-
+		
 		Item item = saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UPDATED)));
 		importService.saveItem(item);
-
+		
 		item = saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UP_TO_DATE)));
 	}
-
+	
 	@Test
-	public void isMappingUpToDate_shouldReturnIfMappingUpdateOnIsAfter() throws Exception {
+	public void isMappingUpToDate_shouldReturnIfMappingUpdateOnIsAfter() throws Exception{
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
-
+		
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
-
+		
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
 		assertTrue(saver.isMappingUpToDate(item, oclMapping));
 	}
-
+	
 	@Test
-	public void isMappingUpToDate_shouldReturnTrueIfItemUpdateOnIsNull() throws Exception {
+	public void isMappingUpToDate_shouldReturnTrueIfItemUpdateOnIsNull() throws Exception{
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
-
+		
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
-
+		
 		oclMapping.setUpdatedOn(dateFormat.parse("2010-02-18T09:10:16Z"));
-
+		
 		assertFalse(saver.isMappingUpToDate(item, oclMapping));
 	}
-
 	@Test
-	public void isMappingUpToDate_shouldReturnTrueIfBothUpdatedOnAreNull() throws Exception {
+	public void isMappingUpToDate_shouldReturnTrueIfBothUpdatedOnAreNull() throws Exception{
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
+		
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
+		
 		assertTrue(saver.isMappingUpToDate(item, oclMapping));
 	}
 
@@ -1663,12 +1682,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	private Matcher<? super ConceptName> hasName(final OclConcept.Name name) {
-		return new TypeSafeMatcher<ConceptName>(ConceptName.class) {
-
+		return new TypeSafeMatcher<ConceptName>(
+		                                        ConceptName.class) {
+			
 			@Override
 			public void describeTo(org.hamcrest.Description description) {
 				description.appendText("Concept name \"").appendText(name.getName()).appendText("\" of type ")
-				        .appendText(name.getNameType());
+						.appendText(name.getNameType());
 			}
 
 			@Override
@@ -1700,14 +1720,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	private Matcher<? super ConceptDescription> hasDescription(final Description description) {
-		return new TypeSafeMatcher<ConceptDescription>(ConceptDescription.class) {
-
+		return new TypeSafeMatcher<ConceptDescription>(
+		                                               ConceptDescription.class) {
+			
 			@Override
 			public void describeTo(org.hamcrest.Description desc) {
-				desc.appendText("Concept description").appendText("[").appendText(description.getDescription())
-				        .appendText("]");
+				desc.appendText("Concept description").appendText("[").appendText(description.getDescription()).appendText("]");
 			}
-
+			
 			@Override
 			protected boolean matchesSafely(ConceptDescription item) {
 				Description actualDescription = new Description();
@@ -1718,7 +1738,8 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	private Matcher<? super ConceptAnswer> hasQuestionAndAnswer(final Concept question, final Concept answer) {
-		return new TypeSafeMatcher<ConceptAnswer>(ConceptAnswer.class) {
+		return new TypeSafeMatcher<ConceptAnswer>(
+		                                          ConceptAnswer.class) {
 
 			@Override
 			public void describeTo(org.hamcrest.Description description) {
@@ -1733,7 +1754,8 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 	private Matcher<? super ConceptMap> hasMapping(final ConceptSource source, final String code,
 	        final ConceptMapType mapType) {
-		return new TypeSafeMatcher<ConceptMap>(ConceptMap.class) {
+		return new TypeSafeMatcher<ConceptMap>(
+		                                       ConceptMap.class) {
 
 			@Override
 			public void describeTo(org.hamcrest.Description description) {
@@ -1811,7 +1833,6 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertTrue(concept.getRetireReason().endsWith("..."));
 	}
 
-
 	@Test
 	public void saveMapping_shouldNotRetireReferenceTermWhenMappingIsRetired() throws Exception {
 		Import update = importService.getLastImport();
@@ -1833,7 +1854,6 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		ConceptReferenceTerm term = conceptService.getConceptReferenceTermByCode("1001", source);
 		assertFalse(term.getRetired());
 	}
-
 
 	@Test
 	public void saveMapping_shouldUnretireReferenceTermAndClearReason() throws Exception {

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -87,6 +87,7 @@ import static org.junit.Assert.fail;
 import static org.openmrs.module.openconceptlab.Utils.version5Uuid;
 
 public class SaverTest extends BaseModuleContextSensitiveTest {
+
 	@Autowired
 	Saver saver;
 
@@ -98,15 +99,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Qualifier("openconceptlab.conceptService")
 	OclConceptService oclConceptService;
 
-	@Autowired
-	@Qualifier("openconceptlab.importService")
+	@Autowired @Qualifier("openconceptlab.importService")
 	ImportService importService;
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
 
-	private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-
+	private final SimpleDateFormat dateFormat = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss'Z'");
+	
 	private Import anImport;
 
 	@Before
@@ -120,7 +120,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void stopUpdate() {
 		importService.stopImport(importService.getLastImport());
 	}
-
+	
 	private Subscription generateSubscription() {
 		Subscription sub = new Subscription();
 		sub.setToken("token");
@@ -173,7 +173,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	/**
-	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
+	 * @see Saver#saveConcept(CacheService, Import, OclConcept) 
 	 * @verifies add new names to concept
 	 */
 	@Test
@@ -195,7 +195,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 	}
-
+	
 	private Name newFourthName() {
 		Name fourthName = new Name();
 		fourthName.setExternalId("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
@@ -205,7 +205,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		fourthName.setNameType(ConceptNameType.INDEX_TERM.toString());
 		return fourthName;
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies add new names to concept
@@ -214,6 +214,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldHandleNameTypesWithDashesCorrectly() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
+		
 		Name thirdName = new Name();
 		thirdName.setExternalId("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		thirdName.setName("Third name");
@@ -221,7 +222,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("Fully-Specified");
 		oclConcept.getNames().add(thirdName);
-
+		
 		Name fourthName = new Name();
 		fourthName.setExternalId("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
 		fourthName.setName("Fourth name");
@@ -229,14 +230,17 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		fourthName.setLocalePreferred(false);
 		fourthName.setNameType("Index-Term");
 		oclConcept.getNames().add(fourthName);
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
+		
 		ConceptName thirdConceptName = conceptService.getConceptNameByUuid("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		assertThat(thirdConceptName.getConceptNameType(), equalTo(ConceptNameType.FULLY_SPECIFIED));
+		
 		ConceptName fourthConceptName = conceptService.getConceptNameByUuid("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
 		assertThat(fourthConceptName.getConceptNameType(), equalTo(ConceptNameType.INDEX_TERM));
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -244,7 +248,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldHandleTheNoneNameTypeCorrectly() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
-
+		
 		Name thirdName = new Name();
 		thirdName.setExternalId("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		thirdName.setName("Third name");
@@ -252,12 +256,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("NONE");
 		oclConcept.getNames().add(thirdName);
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
+		
 		ConceptName thirdConceptName = conceptService.getConceptNameByUuid("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		assertThat(thirdConceptName.getConceptNameType(), nullValue());
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -265,7 +271,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAssignUuidToNameWithoutExternalId() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
-
+		
 		Name thirdName = new Name();
 		thirdName.setUuid("12345");
 		thirdName.setName("Third name");
@@ -273,13 +279,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("NONE");
 		oclConcept.getNames().add(thirdName);
-
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
-
+		
 		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
 		Collection<ConceptName> names = concept.getNames(false);
-
+		
 		ConceptName thirdConceptName = null;
 		for (ConceptName name : names) {
 			if (name.getName().equals("Third name")) {
@@ -287,13 +293,12 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 				break;
 			}
 		}
-
+		
 		if (thirdConceptName == null) {
 			fail("Concept " + concept.getUuid() + " did not have the name \"Third name\" loaded successfully");
 		}
-
-		assertThat(thirdConceptName.getUuid(),
-		    equalTo(version5Uuid(oclConcept.getUrl() + "/names/" + thirdName.getUuid()).toString()));
+		
+		assertThat(thirdConceptName.getUuid(), equalTo(version5Uuid(oclConcept.getUrl() + "/names/" + thirdName.getUuid()).toString()));
 	}
 
 	/**
@@ -383,7 +388,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
-	 * @verifies void old names when names are updated with different uuids
+	 * TODO: Not
 	 */
 	@Test
 	public void importConcept_shouldUpdateNamesWithDifferentUuids() throws Exception {
@@ -402,8 +407,8 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		List<Matcher<? super ConceptName>> matchers = new ArrayList<Matcher<? super ConceptName>>();
 		for (Name name : oclConcept.getNames()) {
 			ConceptNameType nameType = (name.getNameType() != null) ? ConceptNameType.valueOf(name.getNameType()) : null;
-			matchers.add(allOf(hasProperty("name", is(name.getName())), hasProperty("conceptNameType", is(nameType))));
-		}
+	        matchers.add(allOf(hasProperty("name", is(name.getName())), hasProperty("conceptNameType", is(nameType))));
+        }
 
 		assertThat(concept.getNames(false), containsInAnyOrder(matchers));
 		assertThat(concept.getNames(true).size(), is(6));
@@ -555,7 +560,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertImported(oclConcept);
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -563,15 +568,19 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAssignUuidToDescriptionWithoutExternalId() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
+		
 		Description desc1 = new Description();
 		desc1.setUuid("12345");
 		desc1.setDescription("test oclConceptDescription");
 		desc1.setLocale(Context.getLocale());
 		oclConcept.getDescriptions().add(desc1);
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
+		
 		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
 		Collection<ConceptDescription> descriptions = concept.getDescriptions();
+		
 		ConceptDescription conceptDescription = null;
 		for (ConceptDescription description : descriptions) {
 			if (description.getDescription().equals("test oclConceptDescription")) {
@@ -579,12 +588,12 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 				break;
 			}
 		}
+		
 		if (conceptDescription == null) {
-			fail("Concept " + concept.getUuid()
-			        + " did not have the description \"test oclConceptDescription\" loaded successfully");
+			fail("Concept " + concept.getUuid() + " did not have the description \"test oclConceptDescription\" loaded successfully");
 		}
-		assertThat(conceptDescription.getUuid(),
-		    equalTo(version5Uuid(oclConcept.getUrl() + "/descriptions/" + desc1.getUuid()).toString()));
+		
+		assertThat(conceptDescription.getUuid(), equalTo(version5Uuid(oclConcept.getUrl() + "/descriptions/" + desc1.getUuid()).toString()));
 	}
 
 	/**
@@ -704,7 +713,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(conceptClass, notNullValue());
 		assertThat(conceptClass.getUuid(), is(version5Uuid("conceptClass/" + concept.getConceptClass()).toString()));
 	}
-
+	
 	/**
 	 * @verifies generate deterministic UUID for new concept class
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
@@ -714,12 +723,17 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		String className = "Drug route";
 		String expectedUuid = version5Uuid("conceptClass/" + className).toString();
+		
 		OclConcept concept = newOclConcept();
 		concept.setConceptClass(className);
+		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept);
+		
 		ConceptClass conceptClass = conceptService.getConceptClassByName(className);
 		assertThat(conceptClass, notNullValue());
 		assertThat(conceptClass.getUuid(), is(expectedUuid));
+		
+		// Verify determinism: calling version5Uuid again with the same seed produces the same UUID
 		assertThat(version5Uuid("conceptClass/" + className).toString(), is(expectedUuid));
 	}
 
@@ -786,16 +800,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		Concept importedConceptWithIndexTerm = conceptService.getConceptByUuid(conceptWithSynonym.getExternalId());
 
-		assertThat(importedConcept.getNames(),
-		    hasItem((Matcher<? super ConceptName>) allOf(
-		        hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
-		        hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConcept.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
+			hasProperty("name", equalTo("Nazwa")))));
 
-		assertThat(importedConceptWithIndexTerm.getNames(),
-		    hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
-		        hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConceptWithIndexTerm.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
+			hasProperty("name", equalTo("Nazwa")))));
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies save concept if versionUrl changed from last anImport
@@ -805,18 +816,18 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		OclConcept concept = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept));
-
+		
 		OclConcept updateConcept = newOclConcept();
 		updateConcept.setVersionUrl(newOtherOclConcept().getVersionUrl());
 		updateConcept.setDatatype("Document");
-
+		
 		Item item = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, updateConcept);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UPDATED)));
-
+		
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		assertThat(importedConcept.getDatatype(), hasProperty("name", equalTo(updateConcept.getDatatype())));
 	}
-
+	
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies skip saving concept if versionUrl didn't change from last anImport
@@ -826,13 +837,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		OclConcept concept = newOclConcept();
 		OclConcept updateConcept = newOclConcept();
-
+			
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept));
-
-		updateConcept.setDatatype("Document");
+		
+		updateConcept.setDatatype("Document");		
 		Item item = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, updateConcept);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UP_TO_DATE)));
-
+		
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		assertThat(importedConcept.getDatatype(), hasProperty("name", equalTo(concept.getDatatype())));
 	}
@@ -871,14 +882,11 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		Concept importedConceptWithIndexTerm = conceptService.getConceptByUuid(conceptWithSynonym.getExternalId());
 
-		assertThat(importedConcept.getNames(),
-		    hasItem((Matcher<? super ConceptName>) allOf(
-		        hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
-		        hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConcept.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
+			hasProperty("name", equalTo("Nazwa")))));
 
-		assertThat(importedConceptWithIndexTerm.getNames(),
-		    hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
-		        hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConceptWithIndexTerm.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
+			hasProperty("name", equalTo("Nazwa")))));
 	}
 
 	@Test
@@ -948,26 +956,26 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertThat(questionConcept.getAnswers(), contains(hasQuestionAndAnswer(questionConcept, answerConcept)));
 	}
-
+	
 	@Test
 	public void importMapping_shouldAddConceptAnswerWithSortWeight() throws Exception {
 		Import update = importService.getLastImport();
-
+		
 		OclConcept question = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, question));
-
+		
 		OclConcept answer = newOtherOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, answer));
-
+		
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType(MapType.Q_AND_A);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(356.0);
-
+		
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
-
+		
 		Concept questionConcept = conceptService.getConceptByUuid(question.getExternalId());
 		Concept answerConcept = conceptService.getConceptByUuid(answer.getExternalId());
 		List<ConceptAnswer> answers = answersForConcept(questionConcept, answerConcept);
@@ -1048,23 +1056,26 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(questionConcept.getAnswers(), not(contains(hasQuestionAndAnswer(questionConcept, answerConcept))));
 	}
 
+
 	@Test
 	public void importMapping_shouldUpdateConceptAnswer() throws Exception {
 		importMapping_shouldAddConceptAnswer();
 		Import update = importService.getLastImport();
+		
 		Concept questionConcept = conceptService.getConceptByUuid(newOclConcept().getExternalId());
 		Concept answerConcept = conceptService.getConceptByUuid(newOtherOclConcept().getExternalId());
+		
 		List<ConceptAnswer> answers = answersForConcept(questionConcept, answerConcept);
 		assertThat(answers.size(), is(1));
 		assertThat(answers.get(0).getSortWeight(), is(1.0)); // Concept Answers are given a sort weight in core if null
-
+		
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType(MapType.Q_AND_A);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(15.0);
-
+		
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		answers = answersForConcept(questionConcept, answerConcept);
 		assertThat(answers.size(), is(1));
@@ -1120,21 +1131,27 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertThat(setConcept.getSetMembers(), contains(memberConcept));
 	}
-
+	
 	@Test
 	public void importMapping_shouldAddConceptSetMemberWithSortWeight() throws Exception {
 		Import update = importService.getLastImport();
+		
 		OclConcept set = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, set));
+		
 		OclConcept member = newOtherOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, member));
+		
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+		
 		oclMapping.setMapType(MapType.SET);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(11.0);
+		
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
+		
 		Concept setConcept = conceptService.getConceptByUuid(set.getExternalId());
 		Concept memberConcept = conceptService.getConceptByUuid(member.getExternalId());
 		List<ConceptSet> members = membersForConceptSet(setConcept, memberConcept);
@@ -1354,6 +1371,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(cm.getConceptMapType(), equalTo(mapType));
 	}
 
+	
 	@Test
 	public void importMapping_shouldUpdateMappingOnylIfItHasBeenUpdatedSinceLastImport() throws Exception {
 		OclConcept oclConcept = newOclConcept();
@@ -1369,55 +1387,56 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setUrl("/orgs/CIELTEST/sources/CIELTEST/mappings/303");
 
 		importService.saveItem(saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping));
-
+		
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
-
+		
 		Item item = saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UPDATED)));
 		importService.saveItem(item);
-
+		
 		item = saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UP_TO_DATE)));
 	}
-
+	
 	@Test
-	public void isMappingUpToDate_shouldReturnIfMappingUpdateOnIsAfter() throws Exception {
+	public void isMappingUpToDate_shouldReturnIfMappingUpdateOnIsAfter() throws Exception{
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
-
+		
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
-
+		
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
 		assertTrue(saver.isMappingUpToDate(item, oclMapping));
 	}
-
+	
 	@Test
-	public void isMappingUpToDate_shouldReturnTrueIfItemUpdateOnIsNull() throws Exception {
+	public void isMappingUpToDate_shouldReturnTrueIfItemUpdateOnIsNull() throws Exception{
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
-
+		
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
-
+		
 		oclMapping.setUpdatedOn(dateFormat.parse("2010-02-18T09:10:16Z"));
-
+		
 		assertFalse(saver.isMappingUpToDate(item, oclMapping));
 	}
-
 	@Test
-	public void isMappingUpToDate_shouldReturnTrueIfBothUpdatedOnAreNull() throws Exception {
+	public void isMappingUpToDate_shouldReturnTrueIfBothUpdatedOnAreNull() throws Exception{
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
+		
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
+		
 		assertTrue(saver.isMappingUpToDate(item, oclMapping));
 	}
 
@@ -1469,283 +1488,6 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Concept fromConcept = conceptService.getConceptByUuid(oclConcept.getExternalId());
 		assertThat(fromConcept.getConceptMappings().size(), is(1));
 
-	}
-
-	public OclConcept newOclConcept() {
-		OclConcept oclConcept = new OclConcept();
-
-		oclConcept.setExternalId("6c1bbb30-55f6-11e4-8ed6-0800200c9a66");
-
-		oclConcept.setConceptClass("Test");
-		oclConcept.setDatatype("N/A");
-		oclConcept.setDateCreated(new Date());
-		oclConcept.setDateUpdated(new Date());
-
-		oclConcept.setUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
-		oclConcept.setVersionUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/54ea96d28a86f20421474a3a/");
-
-		List<Description> descriptions = new ArrayList<OclConcept.Description>();
-		Description description = new Description();
-		description.setExternalId("a54594cf-7612-46c3-90f3-10599f4e3223");
-		description.setDescription("Test description");
-		description.setLocale(Context.getLocale());
-		descriptions.add(description);
-		oclConcept.setDescriptions(descriptions);
-
-		List<Name> names = new ArrayList<OclConcept.Name>();
-		Name name = new Name();
-		name.setExternalId("051ba9d7-755a-4301-87b3-8e6466f3d3fd");
-		name.setName("Test name");
-		name.setLocale(Context.getLocale());
-		name.setLocalePreferred(true);
-		name.setNameType(ConceptNameType.FULLY_SPECIFIED.toString());
-		names.add(name);
-
-		Name secondName = new Name();
-		secondName.setExternalId("e24eef27-60fa-41d2-ae23-93cc1e6bb153");
-		secondName.setName("Second name");
-		secondName.setLocale(Context.getLocale());
-		secondName.setLocalePreferred(false);
-		names.add(secondName);
-
-		Name secondNameShort = new Name();
-		secondNameShort.setExternalId("ebfd0b33-44e5-43d1-b2d9-9a08f9f3c230");
-		secondNameShort.setName("Second name");
-		secondNameShort.setLocale(Context.getLocale());
-		secondNameShort.setLocalePreferred(false);
-		secondNameShort.setNameType(ConceptNameType.SHORT.toString());
-		names.add(secondNameShort);
-
-		oclConcept.setNames(names);
-
-		return oclConcept;
-	}
-
-	public OclConcept newOtherOclConcept() {
-		OclConcept oclConcept = new OclConcept();
-
-		oclConcept.setExternalId("83f7d006-054a-4a76-a7ef-dc5cfbd125d2");
-
-		oclConcept.setConceptClass("Test");
-		oclConcept.setDatatype("N/A");
-		oclConcept.setDateCreated(new Date());
-		oclConcept.setDateUpdated(new Date());
-
-		oclConcept.setUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
-		oclConcept.setVersionUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/54ea96d38a86f20421474a3c/");
-
-		List<Description> descriptons = new ArrayList<OclConcept.Description>();
-		Description description = new Description();
-		description.setExternalId("f6b743ac-1210-4953-bc98-db4e805754b9");
-		description.setDescription("Other description");
-		description.setLocale(Context.getLocale());
-		descriptons.add(description);
-		oclConcept.setDescriptions(descriptons);
-
-		List<Name> names = new ArrayList<OclConcept.Name>();
-		Name name = new Name();
-		name.setExternalId("9fc16f6f-d016-493a-95fd-26284853c064");
-		name.setName("Other name");
-		name.setLocale(Context.getLocale());
-		name.setLocalePreferred(true);
-		name.setNameType(ConceptNameType.FULLY_SPECIFIED.toString());
-		names.add(name);
-
-		Name secondName = new Name();
-		secondName.setExternalId("54ff1113-3705-4510-b01b-1d89cc09b912");
-		secondName.setName("Other second name");
-		secondName.setLocale(Context.getLocale());
-		secondName.setLocalePreferred(false);
-		names.add(secondName);
-
-		oclConcept.setNames(names);
-
-		return oclConcept;
-	}
-
-	public OclConcept newOclNumericConcept() {
-		OclConcept oclConcept = new OclConcept();
-
-		oclConcept.setExternalId("c2faa33d-427d-11ec-986b-0242ac110002");
-
-		oclConcept.setConceptClass("Question");
-		oclConcept.setDatatype("Numeric");
-		oclConcept.setDateCreated(new Date());
-		oclConcept.setDateUpdated(new Date());
-
-		oclConcept.setUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1003/");
-		oclConcept.setVersionUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1003/54ea96d28a86f20421474a3a/");
-
-		List<Name> names = new ArrayList<OclConcept.Name>();
-		Name name = new Name();
-		name.setExternalId("051ba9d7-755a-4301-87b3-8e6466f3d3fd");
-		name.setName("Test Numeric");
-		name.setLocale(Context.getLocale());
-		name.setLocalePreferred(true);
-		name.setNameType(ConceptNameType.FULLY_SPECIFIED.toString());
-		names.add(name);
-		oclConcept.setNames(names);
-
-		OclConcept.Extras extras = new OclConcept.Extras();
-		extras.setLowAbsolute(0.0);
-		extras.setLowCritical(2.0);
-		extras.setLowNormal(5.0);
-		extras.setHiNormal(8.0);
-		extras.setHiCritical(10.0);
-		extras.setHiAbsolute(12.0);
-		extras.setAllowDecimal(true);
-		extras.setUnits("units");
-		oclConcept.setExtras(extras);
-
-		return oclConcept;
-	}
-
-	private List<ConceptAnswer> answersForConcept(Concept question, Concept answer) {
-		List<ConceptAnswer> l = new ArrayList<>();
-		for (ConceptAnswer ca : question.getAnswers()) {
-			if (ca.getConcept().equals(question) && ca.getAnswerConcept().equals(answer)) {
-				l.add(ca);
-			}
-		}
-		return l;
-	}
-
-	private List<ConceptSet> membersForConceptSet(Concept set, Concept member) {
-		List<ConceptSet> l = new ArrayList<>();
-		for (ConceptSet cs : set.getConceptSets()) {
-			if (cs.getConceptSet().equals(set) && cs.getConcept().equals(member)) {
-				l.add(cs);
-			}
-		}
-		return l;
-	}
-
-	private OclMapping.Extras newOclMappingExtras(Double sortWeight) {
-		OclMapping.Extras extras = new OclMapping.Extras();
-		extras.setSortWeight(sortWeight);
-		return extras;
-	}
-
-	private Concept assertImported(OclConcept oclConcept) {
-		Concept concept;
-		if (oclConcept.getExternalId() != null) {
-			concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
-		} else {
-			concept = conceptService.getConcept(version5Uuid(oclConcept.getUrl()).toString());
-		}
-
-		assertThat(concept, is(notNullValue()));
-
-		ConceptClass conceptClass = conceptService.getConceptClassByName(oclConcept.getConceptClass());
-		assertThat(concept.getConceptClass(), is(conceptClass));
-
-		ConceptDatatype conceptDatatype = conceptService.getConceptDatatypeByName(oclConcept.getDatatype());
-		assertThat(concept.getDatatype(), is(conceptDatatype));
-		assertThat(concept.getNames(false), containsNamesInAnyOrder(oclConcept.getNames()));
-		assertThat(concept.getDescriptions(), containsDescriptionsInAnyOrder(oclConcept.getDescriptions()));
-
-		return concept;
-	}
-
-	private ConceptNumeric assertImportedConceptNumeric(OclConcept oclConcept) {
-		Concept concept = assertImported(oclConcept);
-		assertTrue(concept instanceof ConceptNumeric);
-		ConceptNumeric cn = (ConceptNumeric) concept;
-		assertThat(Utils.getAllowDecimal(cn), is(oclConcept.getExtras().getAllowDecimal()));
-		assertThat(cn.getHiAbsolute(), is(oclConcept.getExtras().getHiAbsolute()));
-		assertThat(cn.getHiCritical(), is(oclConcept.getExtras().getHiCritical()));
-		assertThat(cn.getHiNormal(), is(oclConcept.getExtras().getHiNormal()));
-		assertThat(cn.getLowAbsolute(), is(oclConcept.getExtras().getLowAbsolute()));
-		assertThat(cn.getLowCritical(), is(oclConcept.getExtras().getLowCritical()));
-		assertThat(cn.getLowNormal(), is(oclConcept.getExtras().getLowNormal()));
-		assertThat(cn.getUnits(), is(oclConcept.getExtras().getUnits()));
-		return cn;
-	}
-
-	private Matcher<? super ConceptName> hasName(final OclConcept.Name name) {
-		return new TypeSafeMatcher<ConceptName>(ConceptName.class) {
-
-			@Override
-			public void describeTo(org.hamcrest.Description description) {
-				description.appendText("Concept name \"").appendText(name.getName()).appendText("\" of type ")
-				        .appendText(name.getNameType());
-			}
-
-			@Override
-			public boolean matchesSafely(ConceptName actual) {
-				Name actualName = new Name();
-				actualName.copyFrom(actual);
-
-				return actualName.equals(name);
-			}
-		};
-	}
-
-	private Matcher<Iterable<? extends ConceptName>> containsNamesInAnyOrder(List<OclConcept.Name> names) {
-		List<Matcher<? super ConceptName>> matchers = new ArrayList<Matcher<? super ConceptName>>();
-		for (Name name : names) {
-			matchers.add(hasName(name));
-		}
-
-		return new IsIterableContainingInAnyOrder<ConceptName>(matchers);
-	}
-
-	private Matcher<Iterable<? extends ConceptDescription>> containsDescriptionsInAnyOrder(List<Description> descriptons) {
-		List<Matcher<? super ConceptDescription>> matchers = new ArrayList<Matcher<? super ConceptDescription>>();
-		for (Description description : descriptons) {
-			matchers.add(hasDescription(description));
-		}
-
-		return new IsIterableContainingInAnyOrder<ConceptDescription>(matchers);
-	}
-
-	private Matcher<? super ConceptDescription> hasDescription(final Description description) {
-		return new TypeSafeMatcher<ConceptDescription>(ConceptDescription.class) {
-
-			@Override
-			public void describeTo(org.hamcrest.Description desc) {
-				desc.appendText("Concept description").appendText("[").appendText(description.getDescription())
-				        .appendText("]");
-			}
-
-			@Override
-			protected boolean matchesSafely(ConceptDescription item) {
-				Description actualDescription = new Description();
-				actualDescription.copyFrom(item);
-				return actualDescription.equals(description);
-			}
-		};
-	}
-
-	private Matcher<? super ConceptAnswer> hasQuestionAndAnswer(final Concept question, final Concept answer) {
-		return new TypeSafeMatcher<ConceptAnswer>(ConceptAnswer.class) {
-
-			@Override
-			public void describeTo(org.hamcrest.Description description) {
-			}
-
-			@Override
-			protected boolean matchesSafely(ConceptAnswer item) {
-				return answer.equals(item.getAnswerConcept()) && question.equals(item.getConcept());
-			}
-		};
-	}
-
-	private Matcher<? super ConceptMap> hasMapping(final ConceptSource source, final String code,
-	        final ConceptMapType mapType) {
-		return new TypeSafeMatcher<ConceptMap>(ConceptMap.class) {
-
-			@Override
-			public void describeTo(org.hamcrest.Description description) {
-			}
-
-			@Override
-			protected boolean matchesSafely(ConceptMap item) {
-				return new EqualsBuilder().append(item.getConceptMapType(), mapType)
-				        .append(item.getConceptReferenceTerm().getConceptSource(), source)
-				        .append(item.getConceptReferenceTerm().getCode(), code).build();
-			}
-		};
 	}
 
 	@Test
@@ -2006,6 +1748,63 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	@Test
+	public void saveConcept_shouldReaddDescriptionWhenRetiredThenReactivated() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		boolean foundDesc = false;
+		for (ConceptDescription desc : concept.getDescriptions()) {
+			if ("Test description".equals(desc.getDescription())) {
+				foundDesc = true;
+				break;
+			}
+		}
+		assertTrue(foundDesc);
+
+		// Retire the description
+		oclConcept.setVersionUrl(oclConcept.getVersionUrl() + "2/");
+		for (OclConcept.Description oclDesc : oclConcept.getDescriptions()) {
+			if ("Test description".equals(oclDesc.getDescription())) {
+				oclDesc.setRetired(true);
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		foundDesc = false;
+		for (ConceptDescription desc : concept.getDescriptions()) {
+			if ("Test description".equals(desc.getDescription())) {
+				foundDesc = true;
+				break;
+			}
+		}
+		assertFalse(foundDesc);
+
+		// Reactivate the description
+		oclConcept.setVersionUrl(oclConcept.getVersionUrl() + "3/");
+		for (OclConcept.Description oclDesc : oclConcept.getDescriptions()) {
+			if ("Test description".equals(oclDesc.getDescription())) {
+				oclDesc.setRetired(false);
+				break;
+			}
+		}
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		foundDesc = false;
+		for (ConceptDescription desc : concept.getDescriptions()) {
+			if ("Test description".equals(desc.getDescription())) {
+				foundDesc = true;
+				break;
+			}
+		}
+		assertTrue(foundDesc);
+	}
+
+	@Test
 	public void saveMapping_shouldNotRetireReferenceTermWhenMappingIsRetired() throws Exception {
 		Import update = importService.getLastImport();
 
@@ -2062,7 +1861,6 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertFalse(BooleanUtils.isTrue(term.getRetired()));
 	}
 
-
 	@Test
 	public void saveMapping_shouldUnretireReferenceTermAndClearReason() throws Exception {
 		Import update = importService.getLastImport();
@@ -2092,6 +1890,286 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		term = conceptService.getConceptReferenceTermByCode("1001", source);
 		assertFalse(term.getRetired());
 		assertNull(term.getRetireReason());
+	}
+
+	public OclConcept newOclConcept() {
+		OclConcept oclConcept = new OclConcept();
+
+		oclConcept.setExternalId("6c1bbb30-55f6-11e4-8ed6-0800200c9a66");
+
+		oclConcept.setConceptClass("Test");
+		oclConcept.setDatatype("N/A");
+		oclConcept.setDateCreated(new Date());
+		oclConcept.setDateUpdated(new Date());
+
+		oclConcept.setUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
+		oclConcept.setVersionUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/54ea96d28a86f20421474a3a/");
+
+		List<Description> descriptions = new ArrayList<OclConcept.Description>();
+		Description description = new Description();
+		description.setExternalId("a54594cf-7612-46c3-90f3-10599f4e3223");
+		description.setDescription("Test description");
+		description.setLocale(Context.getLocale());
+		descriptions.add(description);
+		oclConcept.setDescriptions(descriptions);
+
+		List<Name> names = new ArrayList<OclConcept.Name>();
+		Name name = new Name();
+		name.setExternalId("051ba9d7-755a-4301-87b3-8e6466f3d3fd");
+		name.setName("Test name");
+		name.setLocale(Context.getLocale());
+		name.setLocalePreferred(true);
+		name.setNameType(ConceptNameType.FULLY_SPECIFIED.toString());
+		names.add(name);
+
+		Name secondName = new Name();
+		secondName.setExternalId("e24eef27-60fa-41d2-ae23-93cc1e6bb153");
+		secondName.setName("Second name");
+		secondName.setLocale(Context.getLocale());
+		secondName.setLocalePreferred(false);
+		names.add(secondName);
+
+		Name secondNameShort = new Name();
+		secondNameShort.setExternalId("ebfd0b33-44e5-43d1-b2d9-9a08f9f3c230");
+		secondNameShort.setName("Second name");
+		secondNameShort.setLocale(Context.getLocale());
+		secondNameShort.setLocalePreferred(false);
+		secondNameShort.setNameType(ConceptNameType.SHORT.toString());
+		names.add(secondNameShort);
+
+		oclConcept.setNames(names);
+
+		return oclConcept;
+	}
+
+	public OclConcept newOtherOclConcept() {
+		OclConcept oclConcept = new OclConcept();
+
+		oclConcept.setExternalId("83f7d006-054a-4a76-a7ef-dc5cfbd125d2");
+
+		oclConcept.setConceptClass("Test");
+		oclConcept.setDatatype("N/A");
+		oclConcept.setDateCreated(new Date());
+		oclConcept.setDateUpdated(new Date());
+
+		oclConcept.setUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
+		oclConcept.setVersionUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/54ea96d38a86f20421474a3c/");
+
+		List<Description> descriptons = new ArrayList<OclConcept.Description>();
+		Description description = new Description();
+		description.setExternalId("f6b743ac-1210-4953-bc98-db4e805754b9");
+		description.setDescription("Other description");
+		description.setLocale(Context.getLocale());
+		descriptons.add(description);
+		oclConcept.setDescriptions(descriptons);
+
+		List<Name> names = new ArrayList<OclConcept.Name>();
+		Name name = new Name();
+		name.setExternalId("9fc16f6f-d016-493a-95fd-26284853c064");
+		name.setName("Other name");
+		name.setLocale(Context.getLocale());
+		name.setLocalePreferred(true);
+		name.setNameType(ConceptNameType.FULLY_SPECIFIED.toString());
+		names.add(name);
+
+		Name secondName = new Name();
+		secondName.setExternalId("54ff1113-3705-4510-b01b-1d89cc09b912");
+		secondName.setName("Other second name");
+		secondName.setLocale(Context.getLocale());
+		secondName.setLocalePreferred(false);
+		names.add(secondName);
+
+		oclConcept.setNames(names);
+
+		return oclConcept;
+	}
+
+	public OclConcept newOclNumericConcept() {
+		OclConcept oclConcept = new OclConcept();
+
+		oclConcept.setExternalId("c2faa33d-427d-11ec-986b-0242ac110002");
+
+		oclConcept.setConceptClass("Question");
+		oclConcept.setDatatype("Numeric");
+		oclConcept.setDateCreated(new Date());
+		oclConcept.setDateUpdated(new Date());
+
+		oclConcept.setUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1003/");
+		oclConcept.setVersionUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1003/54ea96d28a86f20421474a3a/");
+
+		List<Name> names = new ArrayList<OclConcept.Name>();
+		Name name = new Name();
+		name.setExternalId("051ba9d7-755a-4301-87b3-8e6466f3d3fd");
+		name.setName("Test Numeric");
+		name.setLocale(Context.getLocale());
+		name.setLocalePreferred(true);
+		name.setNameType(ConceptNameType.FULLY_SPECIFIED.toString());
+		names.add(name);
+		oclConcept.setNames(names);
+
+		OclConcept.Extras extras = new OclConcept.Extras();
+		extras.setLowAbsolute(0.0);
+		extras.setLowCritical(2.0);
+		extras.setLowNormal(5.0);
+		extras.setHiNormal(8.0);
+		extras.setHiCritical(10.0);
+		extras.setHiAbsolute(12.0);
+		extras.setAllowDecimal(true);
+		extras.setUnits("units");
+		oclConcept.setExtras(extras);
+
+		return oclConcept;
+	}
+
+	private List<ConceptAnswer> answersForConcept(Concept question, Concept answer) {
+		List<ConceptAnswer> l = new ArrayList<>();
+		for (ConceptAnswer ca : question.getAnswers()) {
+			if (ca.getConcept().equals(question) && ca.getAnswerConcept().equals(answer)) {
+				l.add(ca);
+			}
+		}
+		return l;
+	}
+
+	private List<ConceptSet> membersForConceptSet(Concept set, Concept member) {
+		List<ConceptSet> l = new ArrayList<>();
+		for (ConceptSet cs : set.getConceptSets()) {
+			if (cs.getConceptSet().equals(set) && cs.getConcept().equals(member)) {
+				l.add(cs);
+			}
+		}
+		return l;
+	}
+
+	private OclMapping.Extras newOclMappingExtras(Double sortWeight) {
+		OclMapping.Extras extras = new OclMapping.Extras();
+		extras.setSortWeight(sortWeight);
+		return extras;
+	}
+
+	private Concept assertImported(OclConcept oclConcept) {
+		Concept concept;
+		if (oclConcept.getExternalId() != null) {
+			concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		} else {
+			concept = conceptService.getConcept(version5Uuid(oclConcept.getUrl()).toString());
+		}
+
+		assertThat(concept, is(notNullValue()));
+
+		ConceptClass conceptClass = conceptService.getConceptClassByName(oclConcept.getConceptClass());
+		assertThat(concept.getConceptClass(), is(conceptClass));
+
+		ConceptDatatype conceptDatatype = conceptService.getConceptDatatypeByName(oclConcept.getDatatype());
+		assertThat(concept.getDatatype(), is(conceptDatatype));
+		assertThat(concept.getNames(false), containsNamesInAnyOrder(oclConcept.getNames()));
+		assertThat(concept.getDescriptions(), containsDescriptionsInAnyOrder(oclConcept.getDescriptions()));
+
+		return concept;
+	}
+
+	private ConceptNumeric assertImportedConceptNumeric(OclConcept oclConcept) {
+		Concept concept = assertImported(oclConcept);
+		assertTrue(concept instanceof ConceptNumeric);
+		ConceptNumeric cn = (ConceptNumeric) concept;
+		assertThat(Utils.getAllowDecimal(cn), is(oclConcept.getExtras().getAllowDecimal()));
+		assertThat(cn.getHiAbsolute(), is(oclConcept.getExtras().getHiAbsolute()));
+		assertThat(cn.getHiCritical(), is(oclConcept.getExtras().getHiCritical()));
+		assertThat(cn.getHiNormal(), is(oclConcept.getExtras().getHiNormal()));
+		assertThat(cn.getLowAbsolute(), is(oclConcept.getExtras().getLowAbsolute()));
+		assertThat(cn.getLowCritical(), is(oclConcept.getExtras().getLowCritical()));
+		assertThat(cn.getLowNormal(), is(oclConcept.getExtras().getLowNormal()));
+		assertThat(cn.getUnits(), is(oclConcept.getExtras().getUnits()));
+		return cn;
+	}
+
+	private Matcher<? super ConceptName> hasName(final OclConcept.Name name) {
+		return new TypeSafeMatcher<ConceptName>(
+		                                        ConceptName.class) {
+			
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+				description.appendText("Concept name \"").appendText(name.getName()).appendText("\" of type ")
+						.appendText(name.getNameType());
+			}
+
+			@Override
+			public boolean matchesSafely(ConceptName actual) {
+				Name actualName = new Name();
+				actualName.copyFrom(actual);
+
+				return actualName.equals(name);
+			}
+		};
+	}
+
+	private Matcher<Iterable<? extends ConceptName>> containsNamesInAnyOrder(List<OclConcept.Name> names) {
+		List<Matcher<? super ConceptName>> matchers = new ArrayList<Matcher<? super ConceptName>>();
+		for (Name name : names) {
+			matchers.add(hasName(name));
+		}
+
+		return new IsIterableContainingInAnyOrder<ConceptName>(matchers);
+	}
+
+	private Matcher<Iterable<? extends ConceptDescription>> containsDescriptionsInAnyOrder(List<Description> descriptons) {
+		List<Matcher<? super ConceptDescription>> matchers = new ArrayList<Matcher<? super ConceptDescription>>();
+		for (Description description : descriptons) {
+			matchers.add(hasDescription(description));
+		}
+
+		return new IsIterableContainingInAnyOrder<ConceptDescription>(matchers);
+	}
+
+	private Matcher<? super ConceptDescription> hasDescription(final Description description) {
+		return new TypeSafeMatcher<ConceptDescription>(
+		                                               ConceptDescription.class) {
+			
+			@Override
+			public void describeTo(org.hamcrest.Description desc) {
+				desc.appendText("Concept description").appendText("[").appendText(description.getDescription()).appendText("]");
+			}
+			
+			@Override
+			protected boolean matchesSafely(ConceptDescription item) {
+				Description actualDescription = new Description();
+				actualDescription.copyFrom(item);
+				return actualDescription.equals(description);
+			}
+		};
+	}
+
+	private Matcher<? super ConceptAnswer> hasQuestionAndAnswer(final Concept question, final Concept answer) {
+		return new TypeSafeMatcher<ConceptAnswer>(
+		                                          ConceptAnswer.class) {
+
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+			}
+
+			@Override
+			protected boolean matchesSafely(ConceptAnswer item) {
+				return answer.equals(item.getAnswerConcept()) && question.equals(item.getConcept());
+			}
+		};
+	}
+
+	private Matcher<? super ConceptMap> hasMapping(final ConceptSource source, final String code,
+	        final ConceptMapType mapType) {
+		return new TypeSafeMatcher<ConceptMap>(
+		                                       ConceptMap.class) {
+
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+			}
+
+			@Override
+			protected boolean matchesSafely(ConceptMap item) {
+				return new EqualsBuilder().append(item.getConceptMapType(), mapType)
+				        .append(item.getConceptReferenceTerm().getConceptSource(), source)
+				        .append(item.getConceptReferenceTerm().getCode(), code).build();
+			}
+		};
 	}
 
 	private interface IPredicate<T> {

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -1812,12 +1812,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
 
 		// First create the mapping
-		OclMapping oclMapping = new OclMapping();
-		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
-		oclMapping.setMapType("SAME-AS");
-		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
-		oclMapping.setToSourceName("SNOMED CT");
-		oclMapping.setToConceptCode("1001");
+		OclMapping oclMapping = newOclMapping();
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		oclMapping.setRetired(true);
@@ -1846,12 +1841,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		OclConcept oclConcept = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
 
-		OclMapping oclMapping = new OclMapping();
-		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
-		oclMapping.setMapType("SAME-AS");
-		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
-		oclMapping.setToSourceName("SNOMED CT");
-		oclMapping.setToConceptCode("1001");
+		OclMapping oclMapping = newOclMapping();
 		oclMapping.setRetired(true);
 
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
@@ -1869,12 +1859,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
 
 		// First create the mapping and get the reference term
-		OclMapping oclMapping = new OclMapping();
-		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
-		oclMapping.setMapType("SAME-AS");
-		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
-		oclMapping.setToSourceName("SNOMED CT");
-		oclMapping.setToConceptCode("1001");
+		OclMapping oclMapping = newOclMapping();
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 
 		// Actually retire the reference term so the unretire path is exercised
@@ -1940,6 +1925,16 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclConcept.setNames(names);
 
 		return oclConcept;
+	}
+
+	public OclMapping newOclMapping() {
+		OclMapping oclMapping = new OclMapping();
+		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+		oclMapping.setMapType("SAME-AS");
+		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
+		oclMapping.setToSourceName("SNOMED CT");
+		oclMapping.setToConceptCode("1001");
+		return oclMapping;
 	}
 
 	public OclConcept newOtherOclConcept() {

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -1795,6 +1795,22 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(concept.getRetireReason(), is(OpenConceptLabConstants.DEFAULT_RETIRE_REASON));
 	}
 
+	@Test
+	public void saveConcept_shouldTruncateLongRetireReason() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		oclConcept.setRetired(true);
+		String longReason = new String(new char[300]).replace('\0', 'x');
+		oclConcept.setRetireReason(longReason);
+
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		assertTrue(concept.isRetired());
+		assertThat(concept.getRetireReason().length(), is(255));
+		assertTrue(concept.getRetireReason().endsWith("..."));
+	}
+
 
 	@Test
 	public void saveMapping_shouldNotRetireReferenceTermWhenMappingIsRetired() throws Exception {

--- a/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/importer/SaverTest.java
@@ -43,6 +43,7 @@ import org.openmrs.module.openconceptlab.ImportService;
 import org.openmrs.module.openconceptlab.Item;
 import org.openmrs.module.openconceptlab.ItemState;
 import org.openmrs.module.openconceptlab.OclConceptService;
+import org.openmrs.module.openconceptlab.OpenConceptLabConstants;
 import org.openmrs.module.openconceptlab.Subscription;
 import org.openmrs.module.openconceptlab.Utils;
 import org.openmrs.module.openconceptlab.ValidationType;
@@ -86,7 +87,6 @@ import static org.junit.Assert.fail;
 import static org.openmrs.module.openconceptlab.Utils.version5Uuid;
 
 public class SaverTest extends BaseModuleContextSensitiveTest {
-
 	@Autowired
 	Saver saver;
 
@@ -98,14 +98,15 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	@Qualifier("openconceptlab.conceptService")
 	OclConceptService oclConceptService;
 
-	@Autowired @Qualifier("openconceptlab.importService")
+	@Autowired
+	@Qualifier("openconceptlab.importService")
 	ImportService importService;
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
 
-	private final SimpleDateFormat dateFormat = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss'Z'");
-	
+	private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
 	private Import anImport;
 
 	@Before
@@ -119,7 +120,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void stopUpdate() {
 		importService.stopImport(importService.getLastImport());
 	}
-	
+
 	private Subscription generateSubscription() {
 		Subscription sub = new Subscription();
 		sub.setToken("token");
@@ -172,7 +173,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	/**
-	 * @see Saver#saveConcept(CacheService, Import, OclConcept) 
+	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies add new names to concept
 	 */
 	@Test
@@ -194,7 +195,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
 	}
-	
+
 	private Name newFourthName() {
 		Name fourthName = new Name();
 		fourthName.setExternalId("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
@@ -204,7 +205,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		fourthName.setNameType(ConceptNameType.INDEX_TERM.toString());
 		return fourthName;
 	}
-	
+
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies add new names to concept
@@ -213,7 +214,6 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldHandleNameTypesWithDashesCorrectly() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
-		
 		Name thirdName = new Name();
 		thirdName.setExternalId("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		thirdName.setName("Third name");
@@ -221,7 +221,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("Fully-Specified");
 		oclConcept.getNames().add(thirdName);
-		
+
 		Name fourthName = new Name();
 		fourthName.setExternalId("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
 		fourthName.setName("Fourth name");
@@ -229,17 +229,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		fourthName.setLocalePreferred(false);
 		fourthName.setNameType("Index-Term");
 		oclConcept.getNames().add(fourthName);
-		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
-		
 		ConceptName thirdConceptName = conceptService.getConceptNameByUuid("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		assertThat(thirdConceptName.getConceptNameType(), equalTo(ConceptNameType.FULLY_SPECIFIED));
-		
 		ConceptName fourthConceptName = conceptService.getConceptNameByUuid("a9105ff6-8f9c-449a-9d71-e8b819cc2452");
 		assertThat(fourthConceptName.getConceptNameType(), equalTo(ConceptNameType.INDEX_TERM));
 	}
-	
+
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -247,7 +244,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldHandleTheNoneNameTypeCorrectly() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
-		
+
 		Name thirdName = new Name();
 		thirdName.setExternalId("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		thirdName.setName("Third name");
@@ -255,14 +252,12 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("NONE");
 		oclConcept.getNames().add(thirdName);
-		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
-		
 		ConceptName thirdConceptName = conceptService.getConceptNameByUuid("9040fc62-fc52-4b54-a10b-3dfcdfa588e3");
 		assertThat(thirdConceptName.getConceptNameType(), nullValue());
 	}
-	
+
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -270,7 +265,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAssignUuidToNameWithoutExternalId() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
-		
+
 		Name thirdName = new Name();
 		thirdName.setUuid("12345");
 		thirdName.setName("Third name");
@@ -278,13 +273,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		thirdName.setLocalePreferred(true);
 		thirdName.setNameType("NONE");
 		oclConcept.getNames().add(thirdName);
-		
+
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
-		
+
 		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
 		Collection<ConceptName> names = concept.getNames(false);
-		
+
 		ConceptName thirdConceptName = null;
 		for (ConceptName name : names) {
 			if (name.getName().equals("Third name")) {
@@ -292,12 +287,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 				break;
 			}
 		}
-		
+
 		if (thirdConceptName == null) {
 			fail("Concept " + concept.getUuid() + " did not have the name \"Third name\" loaded successfully");
 		}
-		
-		assertThat(thirdConceptName.getUuid(), equalTo(version5Uuid(oclConcept.getUrl() + "/names/" + thirdName.getUuid()).toString()));
+
+		assertThat(thirdConceptName.getUuid(),
+		    equalTo(version5Uuid(oclConcept.getUrl() + "/names/" + thirdName.getUuid()).toString()));
 	}
 
 	/**
@@ -387,7 +383,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
-	 * TODO: Not
+	 * @verifies void old names when names are updated with different uuids
 	 */
 	@Test
 	public void importConcept_shouldUpdateNamesWithDifferentUuids() throws Exception {
@@ -406,8 +402,8 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		List<Matcher<? super ConceptName>> matchers = new ArrayList<Matcher<? super ConceptName>>();
 		for (Name name : oclConcept.getNames()) {
 			ConceptNameType nameType = (name.getNameType() != null) ? ConceptNameType.valueOf(name.getNameType()) : null;
-	        matchers.add(allOf(hasProperty("name", is(name.getName())), hasProperty("conceptNameType", is(nameType))));
-        }
+			matchers.add(allOf(hasProperty("name", is(name.getName())), hasProperty("conceptNameType", is(nameType))));
+		}
 
 		assertThat(concept.getNames(false), containsInAnyOrder(matchers));
 		assertThat(concept.getNames(true).size(), is(6));
@@ -559,7 +555,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertImported(oclConcept);
 	}
-	
+
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 */
@@ -567,19 +563,15 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	public void importConcept_shouldAssignUuidToDescriptionWithoutExternalId() throws Exception {
 		OclConcept oclConcept = newOclConcept();
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
-		
 		Description desc1 = new Description();
 		desc1.setUuid("12345");
 		desc1.setDescription("test oclConceptDescription");
 		desc1.setLocale(Context.getLocale());
 		oclConcept.getDescriptions().add(desc1);
-		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), anImport, oclConcept);
 		assertImported(oclConcept);
-		
 		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
 		Collection<ConceptDescription> descriptions = concept.getDescriptions();
-		
 		ConceptDescription conceptDescription = null;
 		for (ConceptDescription description : descriptions) {
 			if (description.getDescription().equals("test oclConceptDescription")) {
@@ -587,12 +579,12 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 				break;
 			}
 		}
-		
 		if (conceptDescription == null) {
-			fail("Concept " + concept.getUuid() + " did not have the description \"test oclConceptDescription\" loaded successfully");
+			fail("Concept " + concept.getUuid()
+			        + " did not have the description \"test oclConceptDescription\" loaded successfully");
 		}
-		
-		assertThat(conceptDescription.getUuid(), equalTo(version5Uuid(oclConcept.getUrl() + "/descriptions/" + desc1.getUuid()).toString()));
+		assertThat(conceptDescription.getUuid(),
+		    equalTo(version5Uuid(oclConcept.getUrl() + "/descriptions/" + desc1.getUuid()).toString()));
 	}
 
 	/**
@@ -712,7 +704,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(conceptClass, notNullValue());
 		assertThat(conceptClass.getUuid(), is(version5Uuid("conceptClass/" + concept.getConceptClass()).toString()));
 	}
-	
+
 	/**
 	 * @verifies generate deterministic UUID for new concept class
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
@@ -722,17 +714,12 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		String className = "Drug route";
 		String expectedUuid = version5Uuid("conceptClass/" + className).toString();
-		
 		OclConcept concept = newOclConcept();
 		concept.setConceptClass(className);
-		
 		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept);
-		
 		ConceptClass conceptClass = conceptService.getConceptClassByName(className);
 		assertThat(conceptClass, notNullValue());
 		assertThat(conceptClass.getUuid(), is(expectedUuid));
-		
-		// Verify determinism: calling version5Uuid again with the same seed produces the same UUID
 		assertThat(version5Uuid("conceptClass/" + className).toString(), is(expectedUuid));
 	}
 
@@ -799,13 +786,16 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		Concept importedConceptWithIndexTerm = conceptService.getConceptByUuid(conceptWithSynonym.getExternalId());
 
-		assertThat(importedConcept.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
-			hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConcept.getNames(),
+		    hasItem((Matcher<? super ConceptName>) allOf(
+		        hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
+		        hasProperty("name", equalTo("Nazwa")))));
 
-		assertThat(importedConceptWithIndexTerm.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
-			hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConceptWithIndexTerm.getNames(),
+		    hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
+		        hasProperty("name", equalTo("Nazwa")))));
 	}
-	
+
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies save concept if versionUrl changed from last anImport
@@ -815,18 +805,18 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		OclConcept concept = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept));
-		
+
 		OclConcept updateConcept = newOclConcept();
 		updateConcept.setVersionUrl(newOtherOclConcept().getVersionUrl());
 		updateConcept.setDatatype("Document");
-		
+
 		Item item = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, updateConcept);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UPDATED)));
-		
+
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		assertThat(importedConcept.getDatatype(), hasProperty("name", equalTo(updateConcept.getDatatype())));
 	}
-	
+
 	/**
 	 * @see Saver#saveConcept(CacheService, Import, OclConcept)
 	 * @verifies skip saving concept if versionUrl didn't change from last anImport
@@ -836,13 +826,13 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Import update = importService.getLastImport();
 		OclConcept concept = newOclConcept();
 		OclConcept updateConcept = newOclConcept();
-			
+
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, concept));
-		
-		updateConcept.setDatatype("Document");		
+
+		updateConcept.setDatatype("Document");
 		Item item = saver.saveConcept(new CacheService(conceptService, oclConceptService), update, updateConcept);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UP_TO_DATE)));
-		
+
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		assertThat(importedConcept.getDatatype(), hasProperty("name", equalTo(concept.getDatatype())));
 	}
@@ -881,11 +871,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		Concept importedConcept = conceptService.getConceptByUuid(concept.getExternalId());
 		Concept importedConceptWithIndexTerm = conceptService.getConceptByUuid(conceptWithSynonym.getExternalId());
 
-		assertThat(importedConcept.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
-			hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConcept.getNames(),
+		    hasItem((Matcher<? super ConceptName>) allOf(
+		        hasProperty("conceptNameType", equalTo(ConceptNameType.FULLY_SPECIFIED)),
+		        hasProperty("name", equalTo("Nazwa")))));
 
-		assertThat(importedConceptWithIndexTerm.getNames(), hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
-			hasProperty("name", equalTo("Nazwa")))));
+		assertThat(importedConceptWithIndexTerm.getNames(),
+		    hasItem((Matcher<? super ConceptName>) allOf(hasProperty("conceptNameType", equalTo(ConceptNameType.INDEX_TERM)),
+		        hasProperty("name", equalTo("Nazwa")))));
 	}
 
 	@Test
@@ -955,26 +948,26 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertThat(questionConcept.getAnswers(), contains(hasQuestionAndAnswer(questionConcept, answerConcept)));
 	}
-	
+
 	@Test
 	public void importMapping_shouldAddConceptAnswerWithSortWeight() throws Exception {
 		Import update = importService.getLastImport();
-		
+
 		OclConcept question = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, question));
-		
+
 		OclConcept answer = newOtherOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, answer));
-		
+
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType(MapType.Q_AND_A);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(356.0);
-		
+
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
-		
+
 		Concept questionConcept = conceptService.getConceptByUuid(question.getExternalId());
 		Concept answerConcept = conceptService.getConceptByUuid(answer.getExternalId());
 		List<ConceptAnswer> answers = answersForConcept(questionConcept, answerConcept);
@@ -1055,26 +1048,23 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(questionConcept.getAnswers(), not(contains(hasQuestionAndAnswer(questionConcept, answerConcept))));
 	}
 
-
 	@Test
 	public void importMapping_shouldUpdateConceptAnswer() throws Exception {
 		importMapping_shouldAddConceptAnswer();
 		Import update = importService.getLastImport();
-		
 		Concept questionConcept = conceptService.getConceptByUuid(newOclConcept().getExternalId());
 		Concept answerConcept = conceptService.getConceptByUuid(newOtherOclConcept().getExternalId());
-		
 		List<ConceptAnswer> answers = answersForConcept(questionConcept, answerConcept);
 		assertThat(answers.size(), is(1));
 		assertThat(answers.get(0).getSortWeight(), is(1.0)); // Concept Answers are given a sort weight in core if null
-		
+
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType(MapType.Q_AND_A);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(15.0);
-		
+
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		answers = answersForConcept(questionConcept, answerConcept);
 		assertThat(answers.size(), is(1));
@@ -1130,27 +1120,21 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 		assertThat(setConcept.getSetMembers(), contains(memberConcept));
 	}
-	
+
 	@Test
 	public void importMapping_shouldAddConceptSetMemberWithSortWeight() throws Exception {
 		Import update = importService.getLastImport();
-		
 		OclConcept set = newOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, set));
-		
 		OclConcept member = newOtherOclConcept();
 		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, member));
-		
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
-		
 		oclMapping.setMapType(MapType.SET);
 		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
 		oclMapping.setToConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1002/");
 		oclMapping.setSortWeight(11.0);
-		
 		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
-		
 		Concept setConcept = conceptService.getConceptByUuid(set.getExternalId());
 		Concept memberConcept = conceptService.getConceptByUuid(member.getExternalId());
 		List<ConceptSet> members = membersForConceptSet(setConcept, memberConcept);
@@ -1370,7 +1354,6 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		assertThat(cm.getConceptMapType(), equalTo(mapType));
 	}
 
-	
 	@Test
 	public void importMapping_shouldUpdateMappingOnylIfItHasBeenUpdatedSinceLastImport() throws Exception {
 		OclConcept oclConcept = newOclConcept();
@@ -1386,56 +1369,55 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 		oclMapping.setUrl("/orgs/CIELTEST/sources/CIELTEST/mappings/303");
 
 		importService.saveItem(saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping));
-		
+
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
-		
+
 		Item item = saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UPDATED)));
 		importService.saveItem(item);
-		
+
 		item = saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
 		assertThat(item, hasProperty("state", equalTo(ItemState.UP_TO_DATE)));
 	}
-	
+
 	@Test
-	public void isMappingUpToDate_shouldReturnIfMappingUpdateOnIsAfter() throws Exception{
+	public void isMappingUpToDate_shouldReturnIfMappingUpdateOnIsAfter() throws Exception {
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
-		
+
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
-		
+
 		oclMapping.setUpdatedOn(dateFormat.parse("2008-02-18T09:10:16Z"));
 		assertTrue(saver.isMappingUpToDate(item, oclMapping));
 	}
-	
+
 	@Test
-	public void isMappingUpToDate_shouldReturnTrueIfItemUpdateOnIsNull() throws Exception{
+	public void isMappingUpToDate_shouldReturnTrueIfItemUpdateOnIsNull() throws Exception {
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
-		
+
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
-		
+
 		oclMapping.setUpdatedOn(dateFormat.parse("2010-02-18T09:10:16Z"));
-		
+
 		assertFalse(saver.isMappingUpToDate(item, oclMapping));
 	}
+
 	@Test
-	public void isMappingUpToDate_shouldReturnTrueIfBothUpdatedOnAreNull() throws Exception{
+	public void isMappingUpToDate_shouldReturnTrueIfBothUpdatedOnAreNull() throws Exception {
 		Import update = importService.getLastImport();
 
 		OclMapping oclMapping = new OclMapping();
 		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
 		oclMapping.setMapType("SAME-AS");
-		
 		Item item = new Item(update, oclMapping, ItemState.ADDED);
-		
 		assertTrue(saver.isMappingUpToDate(item, oclMapping));
 	}
 
@@ -1681,13 +1663,12 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	private Matcher<? super ConceptName> hasName(final OclConcept.Name name) {
-		return new TypeSafeMatcher<ConceptName>(
-		                                        ConceptName.class) {
-			
+		return new TypeSafeMatcher<ConceptName>(ConceptName.class) {
+
 			@Override
 			public void describeTo(org.hamcrest.Description description) {
 				description.appendText("Concept name \"").appendText(name.getName()).appendText("\" of type ")
-						.appendText(name.getNameType());
+				        .appendText(name.getNameType());
 			}
 
 			@Override
@@ -1719,14 +1700,14 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	private Matcher<? super ConceptDescription> hasDescription(final Description description) {
-		return new TypeSafeMatcher<ConceptDescription>(
-		                                               ConceptDescription.class) {
-			
+		return new TypeSafeMatcher<ConceptDescription>(ConceptDescription.class) {
+
 			@Override
 			public void describeTo(org.hamcrest.Description desc) {
-				desc.appendText("Concept description").appendText("[").appendText(description.getDescription()).appendText("]");
+				desc.appendText("Concept description").appendText("[").appendText(description.getDescription())
+				        .appendText("]");
 			}
-			
+
 			@Override
 			protected boolean matchesSafely(ConceptDescription item) {
 				Description actualDescription = new Description();
@@ -1737,8 +1718,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 	}
 
 	private Matcher<? super ConceptAnswer> hasQuestionAndAnswer(final Concept question, final Concept answer) {
-		return new TypeSafeMatcher<ConceptAnswer>(
-		                                          ConceptAnswer.class) {
+		return new TypeSafeMatcher<ConceptAnswer>(ConceptAnswer.class) {
 
 			@Override
 			public void describeTo(org.hamcrest.Description description) {
@@ -1753,8 +1733,7 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 
 	private Matcher<? super ConceptMap> hasMapping(final ConceptSource source, final String code,
 	        final ConceptMapType mapType) {
-		return new TypeSafeMatcher<ConceptMap>(
-		                                       ConceptMap.class) {
+		return new TypeSafeMatcher<ConceptMap>(ConceptMap.class) {
 
 			@Override
 			public void describeTo(org.hamcrest.Description description) {
@@ -1767,6 +1746,108 @@ public class SaverTest extends BaseModuleContextSensitiveTest {
 				        .append(item.getConceptReferenceTerm().getCode(), code).build();
 			}
 		};
+	}
+
+	@Test
+	public void saveConcept_shouldRetireConceptWithReason() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		oclConcept.setRetired(true);
+		oclConcept.setRetireReason("Reason for retirement");
+
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		assertTrue(concept.isRetired());
+		assertThat(concept.getRetireReason(), is("Reason for retirement"));
+	}
+
+	@Test
+	public void saveConcept_shouldUnretireConceptAndClearReason() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		oclConcept.setRetired(true);
+		oclConcept.setRetireReason("Reason for retirement");
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		// Now unretire
+		oclConcept.setRetired(false);
+		oclConcept.setRetireReason(null);
+		oclConcept.setVersionUrl(oclConcept.getVersionUrl() + "2/"); // Increment version
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		assertFalse(concept.isRetired());
+		assertThat(concept.getRetireReason(), is(nullValue()));
+	}
+
+	@Test
+	public void saveConcept_shouldHandleNoRetireReason() throws Exception {
+		Import update = importService.getLastImport();
+		OclConcept oclConcept = newOclConcept();
+		oclConcept.setRetired(true);
+		oclConcept.setRetireReason(null);
+
+		saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept);
+
+		Concept concept = conceptService.getConceptByUuid(oclConcept.getExternalId());
+		assertTrue(concept.isRetired());
+		assertThat(concept.getRetireReason(), is(OpenConceptLabConstants.DEFAULT_RETIRE_REASON));
+	}
+
+
+	@Test
+	public void saveMapping_shouldNotRetireReferenceTermWhenMappingIsRetired() throws Exception {
+		Import update = importService.getLastImport();
+
+		OclConcept oclConcept = newOclConcept();
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
+
+		OclMapping oclMapping = new OclMapping();
+		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+		oclMapping.setMapType("SAME-AS");
+		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
+		oclMapping.setToSourceName("SNOMED CT");
+		oclMapping.setToConceptCode("1001");
+		oclMapping.setRetired(true);
+
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
+
+		ConceptSource source = conceptService.getConceptSourceByName("SNOMED CT");
+		ConceptReferenceTerm term = conceptService.getConceptReferenceTermByCode("1001", source);
+		assertFalse(term.getRetired());
+	}
+
+
+	@Test
+	public void saveMapping_shouldUnretireReferenceTermAndClearReason() throws Exception {
+		Import update = importService.getLastImport();
+
+		OclConcept oclConcept = newOclConcept();
+		importService.saveItem(saver.saveConcept(new CacheService(conceptService, oclConceptService), update, oclConcept));
+
+		// First create the mapping and get the reference term
+		OclMapping oclMapping = new OclMapping();
+		oclMapping.setExternalId("dde0d8cb-b44b-4901-90e6-e5066488814f");
+		oclMapping.setMapType("SAME-AS");
+		oclMapping.setFromConceptUrl("/orgs/CIELTEST/sources/CIELTEST/concepts/1001/");
+		oclMapping.setToSourceName("SNOMED CT");
+		oclMapping.setToConceptCode("1001");
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
+
+		// Actually retire the reference term so the unretire path is exercised
+		ConceptSource source = conceptService.getConceptSourceByName("SNOMED CT");
+		ConceptReferenceTerm term = conceptService.getConceptReferenceTermByCode("1001", source);
+		conceptService.retireConceptReferenceTerm(term, "Retired reason");
+
+		// Now unretire by importing a non-retired mapping with an updated date
+		oclMapping.setRetired(false);
+		oclMapping.setUpdatedOn(new Date());
+		saver.saveMapping(new CacheService(conceptService, oclConceptService), update, oclMapping);
+
+		term = conceptService.getConceptReferenceTermByCode("1001", source);
+		assertFalse(term.getRetired());
+		assertNull(term.getRetireReason());
 	}
 
 	private interface IPredicate<T> {


### PR DESCRIPTION
**Description of what I fixed**
The fix on this PR ensures that when importing concepts and mappings from OCL their retirement status and reasons are correctly synchronized with OpenMRS by reading the OCL retired and retire_reason fields. Specifically, I updated the Saver class to apply these fields to concepts, concept names and reference-term mappings, while retired concept descriptions  correctly removed to align with OpenMRS semantics. The implementation supports reactivation by unretiring/unvoiding objects and clearing reasons when OCL's status changes to active, and it maintains backwards compatibility by defaulting missing reason fields to "Retired in OCL."

**Issue worked on:**
https://openmrs.atlassian.net/browse/OCLOMRS-1126