### PR TITLE
OCLOMRS-1127: Correctly follow slash links

### DIFF
--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java
@@ -15,6 +15,8 @@ import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.NameValuePair;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -100,7 +102,7 @@ public class OclClient {
 		get.setQueryString(query.toArray(new NameValuePair[0]));
 
 		client.executeMethod(get);
-		get = followRedirectsWithoutToken(get);
+		get = followRedirects(get, token);
 
 		if (get.getStatusCode() != 200) {
 			throw new IOException(get.getStatusLine().toString());
@@ -408,8 +410,8 @@ public class OclClient {
 	 * Automatic redirect following is disabled deliberately: OCL's export endpoints answer with a
 	 * cross-host 303 redirect to a pre-signed S3 URL, and commons-httpclient reuses the same request
 	 * (headers included) when following a redirect. Forwarding the OCL token to S3 makes it reject
-	 * the request with a 400, so redirects are instead followed manually, and token-free, by
-	 * {@link #followRedirectsWithoutToken(GetMethod)}.
+	 * the request with a 400, so redirects are instead followed manually by
+	 * {@link #followRedirects(GetMethod, String)}, which drops the token on cross-origin hops.
 	 */
 	private GetMethod constructGetMethod(String url, String token) {
 		GetMethod getMethod = new GetMethod(url);
@@ -425,15 +427,22 @@ public class OclClient {
 		GetMethod getMethod = constructGetMethod(url, token);
 		client.executeMethod(getMethod);
 
-		return followRedirects ? followRedirectsWithoutToken(getMethod) : getMethod;
+		return followRedirects ? followRedirects(getMethod, token) : getMethod;
 	}
 
 	/**
-	 * Follows redirects from an already-executed request, re-issuing each hop without the OCL token
-	 * so the credentials are never forwarded to a (cross-host) redirect target such as the S3 bucket
-	 * backing OCL exports. Returns the response of the final, non-redirect hop.
+	 * Follows redirects from an already-executed request, returning the response of the final,
+	 * non-redirect hop.
+	 * <p>
+	 * Relative {@code Location} values (such as Django's trailing-slash 301 from {@code /export} to
+	 * {@code /export/}) are resolved against the URL of the request being redirected. The OCL token
+	 * is kept for hops that stay on the original origin (scheme, host and port) — same-origin
+	 * redirects still target OCL, which needs the credentials for private collections — but is
+	 * dropped for cross-origin hops such as the pre-signed S3 URL backing OCL exports, which rejects
+	 * requests carrying a foreign {@code Authorization} header.
 	 */
-	private GetMethod followRedirectsWithoutToken(GetMethod getMethod) throws IOException {
+	private GetMethod followRedirects(GetMethod getMethod, String token) throws IOException {
+		URI originalUri = getMethod.getURI();
 		int redirects = 0;
 		while (isRedirect(getMethod.getStatusCode()) && redirects++ < MAX_REDIRECTS) {
 			Header location = getMethod.getResponseHeader("Location");
@@ -441,14 +450,22 @@ public class OclClient {
 				break;
 			}
 
-			String redirectUrl = location.getValue();
+			URI redirectUri = new URI(location.getValue(), true);
+			if (redirectUri.isRelativeURI()) {
+				redirectUri = new URI(getMethod.getURI(), redirectUri);
+			}
 			getMethod.releaseConnection();
 
-			getMethod = constructGetMethod(redirectUrl, null);
+			getMethod = constructGetMethod(redirectUri.toString(), hasSameOrigin(redirectUri, originalUri) ? token : null);
 			client.executeMethod(getMethod);
 		}
 
 		return getMethod;
+	}
+
+	private static boolean hasSameOrigin(URI a, URI b) throws URIException {
+		return StringUtils.equalsIgnoreCase(a.getScheme(), b.getScheme())
+				&& StringUtils.equalsIgnoreCase(a.getHost(), b.getHost()) && a.getPort() == b.getPort();
 	}
 
 	private static boolean isRedirect(int statusCode) {

--- a/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java
+++ b/api/src/main/java/org/openmrs/module/openconceptlab/client/OclClient.java
@@ -450,9 +450,23 @@ public class OclClient {
 				break;
 			}
 
-			URI redirectUri = new URI(location.getValue(), true);
-			if (redirectUri.isRelativeURI()) {
-				redirectUri = new URI(getMethod.getURI(), redirectUri);
+			URI currentUri = getMethod.getURI();
+			URI redirectUri;
+			try {
+				String locationValue = location.getValue();
+				// commons-httpclient 3.x's URI(base, relative) mis-resolves protocol-relative
+				// references ("//host/path") as if they were paths, so make those absolute here.
+				if (locationValue.startsWith("//")) {
+					locationValue = currentUri.getScheme() + ":" + locationValue;
+				}
+				redirectUri = new URI(locationValue, true);
+				if (redirectUri.isRelativeURI()) {
+					redirectUri = new URI(currentUri, redirectUri);
+				}
+			}
+			catch (URIException e) {
+				throw new IOException(
+						"Cannot follow redirect from " + currentUri + " to '" + location.getValue() + "'", e);
 			}
 			getMethod.releaseConnection();
 
@@ -463,9 +477,20 @@ public class OclClient {
 		return getMethod;
 	}
 
-	private static boolean hasSameOrigin(URI a, URI b) throws URIException {
+	static boolean hasSameOrigin(URI a, URI b) throws URIException {
 		return StringUtils.equalsIgnoreCase(a.getScheme(), b.getScheme())
-				&& StringUtils.equalsIgnoreCase(a.getHost(), b.getHost()) && a.getPort() == b.getPort();
+				&& StringUtils.equalsIgnoreCase(a.getHost(), b.getHost()) && effectivePort(a) == effectivePort(b);
+	}
+
+	/**
+	 * {@link URI#getPort()} is -1 when the URL leaves the port implicit, so an explicit
+	 * {@code :443} and a portless {@code https} URL would otherwise compare as different origins.
+	 */
+	private static int effectivePort(URI uri) {
+		if (uri.getPort() != -1) {
+			return uri.getPort();
+		}
+		return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
 	}
 
 	private static boolean isRedirect(int statusCode) {

--- a/api/src/test/java/org/openmrs/module/openconceptlab/client/OclClientRedirectTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/client/OclClientRedirectTest.java
@@ -32,11 +32,14 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 /**
- * Exercises {@link OclClient}'s HTTP handling against a real, local HTTP server so that the
+ * Exercises {@link OclClient}'s HTTP handling against real, local HTTP servers so that the
  * redirect-following behaviour can be verified end to end. OCL's export endpoints answer with a
- * cross-host redirect (production returns 302, older deployments 303) to a pre-signed S3 URL; these
- * tests confirm the subscription token reaches the OCL host but is never forwarded to the redirect
- * target (which would make S3 reject the request), regardless of which 3xx code is used.
+ * cross-host redirect (production returns 302, older deployments 303) to a pre-signed S3 URL —
+ * simulated here by a second server on another port — and may first answer with a relative
+ * trailing-slash 301 (Django's APPEND_SLASH). These tests confirm the subscription token reaches
+ * the OCL origin (including same-origin redirect hops, needed for private collections) but is never
+ * forwarded to a cross-origin redirect target (which would make S3 reject the request), and that
+ * relative {@code Location} values are resolved rather than executed as host-less requests.
  */
 public class OclClientRedirectTest {
 
@@ -55,6 +58,11 @@ public class OclClientRedirectTest {
 	private HttpServer server;
 
 	private String baseUrl;
+
+	/** A second server on a different port, standing in for the cross-origin S3 download host. */
+	private HttpServer s3Server;
+
+	private String s3BaseUrl;
 
 	private File tempDir;
 
@@ -75,12 +83,19 @@ public class OclClientRedirectTest {
 		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
 		server.start();
 		baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+
+		s3Server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		s3Server.start();
+		s3BaseUrl = "http://127.0.0.1:" + s3Server.getAddress().getPort();
 	}
 
 	@After
 	public void tearDown() {
 		if (server != null) {
 			server.stop(0);
+		}
+		if (s3Server != null) {
+			s3Server.stop(0);
 		}
 		FileUtils.deleteQuietly(tempDir);
 	}
@@ -107,8 +122,8 @@ public class OclClientRedirectTest {
 
 	@Test
 	public void executeExportRequest_shouldNotSendAuthorizationHeaderWhenNoTokenIsConfigured() throws IOException {
-		server.createContext("/coll/v1.0/export", redirectTo(FOUND, baseUrl + "/download"));
-		server.createContext("/download", respondWith(200, "application/zip", "export-data"));
+		server.createContext("/coll/v1.0/export", redirectTo(FOUND, s3BaseUrl + "/download"));
+		s3Server.createContext("/download", respondWith(200, "application/zip", "export-data"));
 
 		GetMethod result = oclClient.executeExportRequest(baseUrl + "/coll", "v1.0", null);
 		try {
@@ -122,10 +137,10 @@ public class OclClientRedirectTest {
 	}
 
 	@Test
-	public void executeExportRequest_shouldStripTokenAcrossEveryRedirectHop() throws IOException {
-		server.createContext("/coll/v1.0/export", redirectTo(FOUND, baseUrl + "/hop1"));
-		server.createContext("/hop1", redirectTo(FOUND, baseUrl + "/hop2"));
-		server.createContext("/hop2", respondWith(200, "application/zip", "export-data"));
+	public void executeExportRequest_shouldStripTokenAcrossEveryCrossOriginRedirectHop() throws IOException {
+		server.createContext("/coll/v1.0/export", redirectTo(FOUND, s3BaseUrl + "/hop1"));
+		s3Server.createContext("/hop1", redirectTo(FOUND, s3BaseUrl + "/hop2"));
+		s3Server.createContext("/hop2", respondWith(200, "application/zip", "export-data"));
 
 		GetMethod result = oclClient.executeExportRequest(baseUrl + "/coll", "v1.0", TOKEN);
 		try {
@@ -133,6 +148,44 @@ public class OclClientRedirectTest {
 			assertThat(authHeaderByPath.get("/coll/v1.0/export"), is(AUTHORIZATION));
 			assertThat(authHeaderByPath.get("/hop1"), is(""));
 			assertThat(authHeaderByPath.get("/hop2"), is(""));
+		}
+		finally {
+			result.releaseConnection();
+		}
+	}
+
+	/**
+	 * Models the production failure: OCL (Django) answers the slash-less export URL with a relative
+	 * trailing-slash 301, which used to be executed as a host-less request ("host parameter is
+	 * null"). The relative location must be resolved against the request URL, and since that hop
+	 * stays on the OCL origin, the token must be kept — private collections reject the request
+	 * otherwise. The subsequent cross-origin hop to S3 must still go out token-free.
+	 */
+	@Test
+	public void executeExportRequest_shouldResolveRelativeRedirectAndKeepTokenOnSameOriginHop() throws IOException {
+		// The JDK server matches contexts by prefix, so this handler sees both the slash-less
+		// request and the trailing-slash one, mirroring Django's APPEND_SLASH behaviour.
+		server.createContext("/coll/v1.0/export", new HttpHandler() {
+
+			@Override
+			public void handle(HttpExchange exchange) throws IOException {
+				if (exchange.getRequestURI().getPath().endsWith("/")) {
+					redirectTo(FOUND, s3BaseUrl + "/download").handle(exchange);
+				} else {
+					redirectTo(MOVED_PERMANENTLY, "/coll/v1.0/export/").handle(exchange);
+				}
+			}
+		});
+		s3Server.createContext("/download", respondWith(200, "application/zip", "export-data"));
+
+		GetMethod result = oclClient.executeExportRequest(baseUrl + "/coll", "v1.0", TOKEN);
+		try {
+			assertThat(result.getStatusCode(), is(200));
+			assertThat(authHeaderByPath.get("/coll/v1.0/export"), is(AUTHORIZATION));
+			assertThat("token must be kept on the same-origin redirect hop",
+					authHeaderByPath.get("/coll/v1.0/export/"), is(AUTHORIZATION));
+			assertThat("token must not be forwarded to the cross-origin redirect target",
+					authHeaderByPath.get("/download"), is(""));
 		}
 		finally {
 			result.releaseConnection();
@@ -167,8 +220,8 @@ public class OclClientRedirectTest {
 	}
 
 	private void assertExportFollowsRedirectWithoutForwardingToken(int redirectStatus) throws IOException {
-		server.createContext("/coll/v1.0/export", redirectTo(redirectStatus, baseUrl + "/download"));
-		server.createContext("/download", respondWith(200, "application/zip", "export-data"));
+		server.createContext("/coll/v1.0/export", redirectTo(redirectStatus, s3BaseUrl + "/download"));
+		s3Server.createContext("/download", respondWith(200, "application/zip", "export-data"));
 
 		GetMethod result = oclClient.executeExportRequest(baseUrl + "/coll", "v1.0", TOKEN);
 		try {
@@ -183,7 +236,7 @@ public class OclClientRedirectTest {
 
 	private void assertVersionProbeTreatsRedirectAsExistingVersion(int redirectStatus) throws IOException {
 		server.createContext("/coll/versions", respondWith(200, "application/json", "[{\"id\":\"HEAD\"},{\"id\":\"v1.0\"}]"));
-		server.createContext("/coll/v1.0/export", redirectTo(redirectStatus, baseUrl + "/download"));
+		server.createContext("/coll/v1.0/export", redirectTo(redirectStatus, s3BaseUrl + "/download"));
 
 		String version = oclClient.fetchLatestOclReleaseVersion(baseUrl + "/coll", TOKEN);
 

--- a/api/src/test/java/org/openmrs/module/openconceptlab/client/OclClientRedirectTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/client/OclClientRedirectTest.java
@@ -9,17 +9,22 @@
  */
 package org.openmrs.module.openconceptlab.client;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.io.FileUtils;
@@ -70,6 +75,9 @@ public class OclClientRedirectTest {
 
 	/** The {@code Authorization} header observed by the server for each requested path ("" if absent). */
 	private final Map<String, String> authHeaderByPath = new ConcurrentHashMap<String, String>();
+
+	/** The raw query string observed by the server for each requested path ("" if absent). */
+	private final Map<String, String> queryByPath = new ConcurrentHashMap<String, String>();
 
 	@Before
 	public void setUp() throws IOException {
@@ -209,6 +217,121 @@ public class OclClientRedirectTest {
 		}
 	}
 
+	/**
+	 * fetchSnapshotUpdates sends its parameters (includeMappings, updatedSince, limit, ...) as a
+	 * query string. Django's APPEND_SLASH 301 carries the query string in its relative
+	 * {@code Location}, and RFC-compliant resolution takes the query from the location, not the
+	 * base — so the parameters must survive the redirected hop, along with the token (same origin).
+	 */
+	@Test
+	public void fetchSnapshotUpdates_shouldKeepQueryParametersAndTokenAcrossRelativeTrailingSlashRedirect()
+			throws IOException {
+		server.createContext("/coll", new HttpHandler() {
+
+			@Override
+			public void handle(HttpExchange exchange) throws IOException {
+				if (exchange.getRequestURI().getPath().endsWith("/")) {
+					respondWithBytes(200, "application/zip", zipWithExportJson()).handle(exchange);
+				} else {
+					String query = exchange.getRequestURI().getRawQuery();
+					redirectTo(MOVED_PERMANENTLY, "/coll/" + (query == null ? "" : "?" + query)).handle(exchange);
+				}
+			}
+		});
+
+		OclClient.OclResponse response = oclClient.fetchSnapshotUpdates(baseUrl + "/coll", TOKEN, new Date(0));
+
+		assertThat(response.getContentStream().read(), is((int) '{'));
+		assertThat(queryByPath.get("/coll"), containsString("limit=100000"));
+		assertThat(queryByPath.get("/coll"), containsString("updatedSince="));
+		assertThat("query parameters must survive the redirected hop", queryByPath.get("/coll/"),
+				is(queryByPath.get("/coll")));
+		assertThat(authHeaderByPath.get("/coll/"), is(AUTHORIZATION));
+	}
+
+	@Test
+	public void executeExportRequest_shouldReportMalformedLocationHeaderAsDiagnosableIOException() throws IOException {
+		String malformedLocation = "http://[bad";
+		server.createContext("/coll/v1.0/export", redirectTo(FOUND, malformedLocation));
+
+		try {
+			GetMethod result = oclClient.executeExportRequest(baseUrl + "/coll", "v1.0", TOKEN);
+			result.releaseConnection();
+			fail("Expected an IOException for the malformed Location header");
+		}
+		catch (IOException expected) {
+			assertThat(expected.getMessage(), containsString(malformedLocation));
+			assertThat(expected.getMessage(), containsString("/coll/v1.0/export"));
+		}
+	}
+
+	@Test
+	public void executeExportRequest_shouldRejectRedirectThatIsMissingALocationHeader() throws IOException {
+		server.createContext("/coll/v1.0/export", new HttpHandler() {
+
+			@Override
+			public void handle(HttpExchange exchange) throws IOException {
+				recordAuth(exchange);
+				exchange.sendResponseHeaders(FOUND, -1);
+				exchange.close();
+			}
+		});
+
+		try {
+			GetMethod result = oclClient.executeExportRequest(baseUrl + "/coll", "v1.0", TOKEN);
+			result.releaseConnection();
+			fail("Expected an IOException for a redirect without a Location header");
+		}
+		catch (IOException expected) {
+			// Redirect following stops and executeExportRequest rejects the still-3xx response.
+		}
+	}
+
+	/**
+	 * A protocol-relative location ({@code //host/path}) inherits the scheme from the request being
+	 * redirected but changes the host — CDN/S3 fronts emit these. It must resolve to an absolute
+	 * URL and count as cross-origin for the token decision.
+	 */
+	@Test
+	public void executeExportRequest_shouldResolveProtocolRelativeLocationAndTreatItAsCrossOrigin() throws IOException {
+		String protocolRelativeLocation = s3BaseUrl.substring("http:".length()) + "/download";
+		server.createContext("/coll/v1.0/export", redirectTo(FOUND, protocolRelativeLocation));
+		s3Server.createContext("/download", respondWith(200, "application/zip", "export-data"));
+
+		GetMethod result = oclClient.executeExportRequest(baseUrl + "/coll", "v1.0", TOKEN);
+		try {
+			assertThat(result.getStatusCode(), is(200));
+			assertThat("token must not be forwarded to the cross-origin redirect target",
+					authHeaderByPath.get("/download"), is(""));
+		}
+		finally {
+			result.releaseConnection();
+		}
+	}
+
+	/**
+	 * The origin check compares each hop against the ORIGINAL request, not the previous hop, so a
+	 * cross-origin detour that redirects back to the OCL origin gets the token re-attached. This
+	 * pins that deliberate choice.
+	 */
+	@Test
+	public void executeExportRequest_shouldReattachTokenWhenCrossOriginHopRedirectsBackToOriginalOrigin()
+			throws IOException {
+		server.createContext("/coll/v1.0/export", redirectTo(FOUND, s3BaseUrl + "/hop"));
+		s3Server.createContext("/hop", redirectTo(FOUND, baseUrl + "/final"));
+		server.createContext("/final", respondWith(200, "application/zip", "export-data"));
+
+		GetMethod result = oclClient.executeExportRequest(baseUrl + "/coll", "v1.0", TOKEN);
+		try {
+			assertThat(result.getStatusCode(), is(200));
+			assertThat(authHeaderByPath.get("/hop"), is(""));
+			assertThat(authHeaderByPath.get("/final"), is(AUTHORIZATION));
+		}
+		finally {
+			result.releaseConnection();
+		}
+	}
+
 	@Test
 	public void fetchLatestOclReleaseVersion_shouldTreatFound302ExportAsAnExistingVersion() throws IOException {
 		assertVersionProbeTreatsRedirectAsExistingVersion(FOUND);
@@ -250,6 +373,8 @@ public class OclClientRedirectTest {
 	private void recordAuth(HttpExchange exchange) {
 		String auth = exchange.getRequestHeaders().getFirst("Authorization");
 		authHeaderByPath.put(exchange.getRequestURI().getPath(), auth == null ? "" : auth);
+		String query = exchange.getRequestURI().getRawQuery();
+		queryByPath.put(exchange.getRequestURI().getPath(), query == null ? "" : query);
 	}
 
 	private HttpHandler redirectTo(final int status, final String location) {
@@ -266,12 +391,15 @@ public class OclClientRedirectTest {
 	}
 
 	private HttpHandler respondWith(final int status, final String contentType, final String body) {
+		return respondWithBytes(status, contentType, body.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private HttpHandler respondWithBytes(final int status, final String contentType, final byte[] bytes) {
 		return new HttpHandler() {
 
 			@Override
 			public void handle(HttpExchange exchange) throws IOException {
 				recordAuth(exchange);
-				byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
 				exchange.getResponseHeaders().add("Content-Type", contentType);
 				exchange.sendResponseHeaders(status, bytes.length);
 				try (OutputStream out = exchange.getResponseBody()) {
@@ -279,5 +407,16 @@ public class OclClientRedirectTest {
 				}
 			}
 		};
+	}
+
+	/** A minimal archive of the shape OCL exports use, so response extraction can complete. */
+	private byte[] zipWithExportJson() throws IOException {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		ZipOutputStream zip = new ZipOutputStream(bytes);
+		zip.putNextEntry(new ZipEntry("export.json"));
+		zip.write("{}".getBytes(StandardCharsets.UTF_8));
+		zip.closeEntry();
+		zip.close();
+		return bytes.toByteArray();
 	}
 }

--- a/api/src/test/java/org/openmrs/module/openconceptlab/client/OclClientTest.java
+++ b/api/src/test/java/org/openmrs/module/openconceptlab/client/OclClientTest.java
@@ -24,6 +24,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.util.DateUtil;
@@ -161,6 +162,24 @@ public class OclClientTest extends MockTest {
 		String collectionVersion = "v1.0";
 		String getMethodUrlWithoutVersion = oclClient.getExportUrl(URL_WITHOUT_VERSION, collectionVersion);
 		assertThat(getMethodUrlWithoutVersion, is(URL_WITHOUT_VERSION + "/v1.0" + "/export"));
+	}
+
+	@Test
+	public void hasSameOrigin_shouldTreatImplicitAndExplicitDefaultPortAsSameOrigin() throws URIException {
+		assertThat(OclClient.hasSameOrigin(uri("https://host/a"), uri("https://host:443/b")), is(true));
+		assertThat(OclClient.hasSameOrigin(uri("http://host/a"), uri("http://host:80/b")), is(true));
+		assertThat(OclClient.hasSameOrigin(uri("HTTPS://HOST/a"), uri("https://host/b")), is(true));
+	}
+
+	@Test
+	public void hasSameOrigin_shouldTreatDifferentSchemeHostOrPortAsDifferentOrigin() throws URIException {
+		assertThat(OclClient.hasSameOrigin(uri("https://host/a"), uri("http://host/a")), is(false));
+		assertThat(OclClient.hasSameOrigin(uri("https://host/a"), uri("https://other/a")), is(false));
+		assertThat(OclClient.hasSameOrigin(uri("https://host:8443/a"), uri("https://host/a")), is(false));
+	}
+
+	private static URI uri(String url) throws URIException {
+		return new URI(url, true);
 	}
 
 	@Test


### PR DESCRIPTION
OCL `/export` links now redirect to `/export/`. Unfortunately, we weren't properly retaining the host on these redirects leading to failures. This updates things to keep working with this (very old) version of the HTTPClient.